### PR TITLE
Fix unregister toolbox overlay on unload

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -33,7 +33,7 @@ function main(options, callbacks) {
 function onUnload(reason) {
   Trace.sysout("onUnload; " + reason);
 
-  ToolboxChrome.unregisterPanelOverlay(StyleEditorOverlay);
+  ToolboxChrome.unregisterToolboxOverlay(ToolboxOverlay);
 
   StartButton.shutdown(reason);
   ToolboxChrome.shutdown(reason);


### PR DESCRIPTION
This pr fix toolbox overlay unregistering which should happen on addon unload