### PR TITLE
Refresh packet-detail tree-view when a packet is selected in the packet-list

### DIFF
--- a/data/inspector/inspector.js
+++ b/data/inspector/inspector.js
@@ -20,8 +20,14 @@ var packets = [];
 renderToolbar();
 renderTabbedBox();
 
+var actions = {
+  selectPacket: function(packet) {
+    packetList.setState({selectedPacket: packet});
+  }
+};
+
 // Render packet list.
-var packetList = React.render(PacketsTabBody(packets),
+var packetList = React.render(PacketsTabBody({packets: packets, actions: actions}),
   document.querySelector("#tabPacketsPane"));
 var globalActorsPane = Pools.render(
   document.querySelector("#globalActorsPane"));
@@ -103,6 +109,10 @@ function appendPacket(packet) {
   }
 
   refreshPackets();
+}
+
+function onPacketSelected(packet) {
+  packetList.setState({ selectedPacket: packet });
 }
 
 // xxxHonza: refactor into an utility object.

--- a/data/inspector/packet-details.js
+++ b/data/inspector/packet-details.js
@@ -22,12 +22,9 @@ var PacketDetails = React.createClass({
   },
 
   render: function() {
-    // xxxHonza: FIXME
-    var packet = (this.props.data && this.props.data.length) ? this.props.data[0] : {};
-
     return (
       DIV({className: "packetDetailsBox"},
-        TreeView({data: packet})
+        TreeView({ key: "packet-detail", data: this.props.data || {} })
       )
     );
   }

--- a/data/inspector/packet-list.js
+++ b/data/inspector/packet-list.js
@@ -32,7 +32,7 @@ var PacketList = React.createClass({
         continue;
       }
       packets[i].key = i;
-      output.push(Packet(packets[i]));
+      output.push(Packet({data: packets[i], actions: this.props.actions}));
     };
 
     return (

--- a/data/inspector/packet.js
+++ b/data/inspector/packet.js
@@ -19,14 +19,14 @@ const { DIV, SPAN, BR, IMG } = Reps.DOM;
 var Packet = React.createClass({
   displayName: "Packet",
   render: function() {
-    var packet = this.props.packet;
+    var packet = this.props.data.packet;
     var type = packet.type ? "\"" + packet.type + "\"" : "";
     var mode = "tiny";
-    var classNames = ["packetPanel", this.props.type];
+    var classNames = ["packetPanel", this.props.data.type];
 
     // xxxHonza TODO: HACK, FIXME
-    var size = this.props.size+""//Str.formatSize(this.props.size);
-    var time = this.props.time;
+    var size = this.props.data.size+""//Str.formatSize(this.props.data.size);
+    var time = this.props.data.time;
 
     // Use String.formatTime, but how to access from the content?
     var timeText = time.toLocaleTimeString() + "." + time.getMilliseconds();
@@ -44,7 +44,7 @@ var Packet = React.createClass({
     }
 
     // xxxHonza: localization
-    if (this.props.type == "send") {
+    if (this.props.data.type == "send") {
       return (
         DIV({className: classNames.join(" "), onClick: this.onClick},
           DIV({className: "body"},
@@ -82,6 +82,7 @@ var Packet = React.createClass({
 
   onClick: function(event) {
     // TODO: refresh the packet details panel.
+    this.props.actions.selectPacket(this.props.data.packet);
   }
 });
 

--- a/data/inspector/packets-tab-body.js
+++ b/data/inspector/packets-tab-body.js
@@ -18,7 +18,10 @@ var PacketsTabBody = React.createClass({
   displayName: "PacketsTabBody",
 
   getInitialState: function() {
-    return { data: this.props.data };
+    return {
+      packets: this.props.packets,
+      selectedPacket: null
+    };
   },
 
   render: function() {
@@ -27,10 +30,11 @@ var PacketsTabBody = React.createClass({
         TBODY({},
           TR({},
             TD({className: "list"},
-              PacketList({data: this.state.data})
+              PacketList({data: this.state.packets,
+                          actions: this.props.actions})
             ),
             TD({className: "details"},
-              PacketDetails({data: this.state.data})
+              PacketDetails({data: this.state.selectedPacket})
             )
           )
         )

--- a/lib/inspector-window.js
+++ b/lib/inspector-window.js
@@ -146,7 +146,7 @@ const InspectorWindow = Class(
     }
 
     let content = this.win.document.getElementById("content");
-    return content.contentWindow;
+    return content && content.contentWindow;
   }
 });
 


### PR DESCRIPTION
This depends on the fix firebug/firebug.sdk#6 and refreshes the packet detail tree-view on packet selection (currently only the minimal changes to activate the feature, without any cleanup or css tweaks)
