### PR TITLE
Fix "do not reset packet-editor on new selectedPacket or sidebar tab change"

### DIFF
--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -41,7 +41,6 @@ var PacketsSidebar = React.createClass({
         ),
         TabPane({eventKey: 2, tab: "Send Packet"},
           PacketEditor({
-            selectedPacket: this.props.selectedPacket,
             actions: this.props.actions
           })
         )

--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -27,9 +27,35 @@ var PacketsSidebar = React.createClass({
 
   displayName: "PacketsSidebar",
 
+  getInitialState: function() {
+    return {
+      activeKey: 1
+    }
+  },
+
+  onTabSelected: function(key) {
+    this.setState({
+      activeKey: key
+    })
+  },
+
+  componentWillReceiveProps: function(nextProps) {
+    // reset activeKey to the "Packet" Detail sidebar
+    // when the parent component pass a new selectedPacket
+    if (nextProps.selectedPacket !== this.selectedPacket) {
+      this.setState({
+        activeKey: 1
+      });
+    }
+  },
+
   render: function() {
     return (
-      TabbedArea({className: "sideBarTabbedArea", animation: false},
+      TabbedArea({
+        className: "sideBarTabbedArea", animation: false,
+        activeKey: this.state.activeKey,
+        onSelect: this.onTabSelected
+      },
         TabPane({eventKey: 1, tab: "Packet Details"},
           PacketDetails({selectedPacket: this.props.selectedPacket})
         ),

--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -27,12 +27,6 @@ var PacketsSidebar = React.createClass({
 
   displayName: "PacketsSidebar",
 
-  getInitialState: function() {
-    return {
-      selectedPacket: null
-    };
-  },
-
   render: function() {
     return (
       TabbedArea({className: "sideBarTabbedArea", animation: false},

--- a/data/inspector/components/tree-editor-view.js
+++ b/data/inspector/components/tree-editor-view.js
@@ -97,21 +97,32 @@ define(function(require, exports, module) {
       nextProps = nextProps || {};
       var data = nextProps.data;
 
-      // no data selected and no default data configured
-      if (!data) {
-        data = nextProps.defaultData || {};
+      var currentState, stateHistory;
+
+      // no previous state or new data set
+      if (!this.state || data) {
+        if (!data) {
+          data = nextProps.defaultData || {};
+        }
+
+        currentState = Immutable.fromJS({
+          data: data,
+          openedKeyPaths: {},
+          editingKeyPath: {}
+        });
+      } else {
+        currentState = this.state.currentState;
       }
 
-      var currentState = Immutable.fromJS({
-        data: data,
-        openedKeyPaths: {},
-        editingKeyPath: {}
-      });
-
-      var stateHistory = Immutable.fromJS({
-        history: [currentState],
-        index: 0
-      });
+      // no previous state or no stateHistory
+      if (!this.state || !this.state.stateHistory) {
+        stateHistory = Immutable.fromJS({
+          history: [currentState],
+          index: 0
+        });
+      } else {
+        stateHistory = this.state.stateHistory
+      }
 
       return {
         currentState: currentState,


### PR DESCRIPTION
This pr fix the "packet-editor reset on new selectedPacket or sidebar tab change" issues and in the process I've added the following new behaviour:

- when a new packet is selected in the packet list the sidebar switch automatically to the "Packet Detail tab" 