### PR TITLE
Fix indentation and js docs on packet-editor and tree-editor-view modules

### DIFF
--- a/data/inspector/components/packet-editor.js
+++ b/data/inspector/components/packet-editor.js
@@ -10,17 +10,19 @@ const ReactBootstrap = require("react-bootstrap");
 const { Reps } = require("reps/repository");
 const { TreeEditorView } = require("./tree-editor-view");
 
-// Shortcuts
+// Constants
 const { DIV } = Reps.DOM;
 
 const ButtonToolbar = React.createFactory(ReactBootstrap.ButtonToolbar);
 const Button = React.createFactory(ReactBootstrap.Button);
 
 /**
- * TODO docs
+ * @template This template rapresents the Packet Editor toolbar
  */
 
 var PacketEditorToolbar = React.createFactory(React.createClass({
+/** @lends PacketEditrView */
+
   displayName: "PacketEditorToolbar",
 
   render: function() {
@@ -48,8 +50,7 @@ var PacketEditorToolbar = React.createFactory(React.createClass({
 }));
 
 /**
- * @template TODO
- *
+ * @template This template represents the PacketEditor sidebar
  */
 var PacketEditor = React.createClass({
   displayName: "PacketEditor",

--- a/data/inspector/components/packet-editor.js
+++ b/data/inspector/components/packet-editor.js
@@ -2,116 +2,115 @@
 
 define(function(require, exports, module) {
 
-  // Dependencies
-  const React = require("react");
-  const ReactBootstrap = require("react-bootstrap");
+// Dependencies
+const React = require("react");
+const ReactBootstrap = require("react-bootstrap");
 
-  // Firebug SDK
-  const { Reps } = require("reps/repository");
-  const { TreeEditorView } = require("./tree-editor-view");
+// Firebug SDK
+const { Reps } = require("reps/repository");
+const { TreeEditorView } = require("./tree-editor-view");
 
-  // Shortcuts
-  const { DIV } = Reps.DOM;
+// Shortcuts
+const { DIV } = Reps.DOM;
 
-  const ButtonToolbar = React.createFactory(ReactBootstrap.ButtonToolbar);
-  const Button = React.createFactory(ReactBootstrap.Button);
+const ButtonToolbar = React.createFactory(ReactBootstrap.ButtonToolbar);
+const Button = React.createFactory(ReactBootstrap.Button);
 
-  /**
-   * TODO docs
-   */
+/**
+ * TODO docs
+ */
 
-  var PacketEditorToolbar = React.createFactory(React.createClass({
-    displayName: "PacketEditorToolbar",
+var PacketEditorToolbar = React.createFactory(React.createClass({
+  displayName: "PacketEditorToolbar",
 
-    render: function() {
-      return ButtonToolbar({className: "toolbar"}, [
-        Button({ onClick: this.props.onSend, key: "send",
-                 bsStyle: "primary", bsSize: "xsmall",
-                 style: { marginLeft: 12, color: 'white' } }, "Send"),
+  render: function() {
+    return ButtonToolbar({className: "toolbar"}, [
+      Button({ onClick: this.props.onSend, key: "send",
+               bsStyle: "primary", bsSize: "xsmall",
+               style: { marginLeft: 12, color: 'white' } }, "Send"),
 
-        Button({ onClick: this.props.onRedo, key: "redo",
-                 className: "pull-right",
-                 disabled: !this.props.isRedoEnabled,
-                 bsStyle: "default", bsSize: "xsmall",
-                 style: { marginRight: 6 } }, "Redo"),
-        Button({ onClick: this.props.onUndo, key: "undo",
-                 className: "pull-right",
-                 disabled: !this.props.isUndoEnabled,
-                 bsStyle: "default", bsSize: "xsmall",
-                 style: { marginRight: 6 } }, "Undo"),
-        Button({ onClick: this.props.onClear, key: "clear",
-                 className: "pull-right",
-                 bsStyle: "danger", bsSize: "xsmall",
-                 style: { marginRight: 6, color: 'white' } }, "Clear")
-      ]);
-    }
-  }));
+      Button({ onClick: this.props.onRedo, key: "redo",
+               className: "pull-right",
+               disabled: !this.props.isRedoEnabled,
+               bsStyle: "default", bsSize: "xsmall",
+               style: { marginRight: 6 } }, "Redo"),
+      Button({ onClick: this.props.onUndo, key: "undo",
+               className: "pull-right",
+               disabled: !this.props.isUndoEnabled,
+               bsStyle: "default", bsSize: "xsmall",
+               style: { marginRight: 6 } }, "Undo"),
+      Button({ onClick: this.props.onClear, key: "clear",
+               className: "pull-right",
+               bsStyle: "danger", bsSize: "xsmall",
+               style: { marginRight: 6, color: 'white' } }, "Clear")
+    ]);
+  }
+}));
 
-  /**
-   * @template TODO
-   *
-   */
-  var PacketEditor = React.createClass({
-    displayName: "PacketEditor",
+/**
+ * @template TODO
+ *
+ */
+var PacketEditor = React.createClass({
+  displayName: "PacketEditor",
 
-    getInitialState: function() {
-      return {
-        selectedPacket: null,
-        defaultData: {
-          to: "root",
-          type: "requestTypes"
-        }
-      };
-    },
+  getInitialState: function() {
+    return {
+      selectedPacket: null,
+      defaultData: {
+        to: "root",
+        type: "requestTypes"
+      }
+    };
+  },
 
-    componentWillReceiveProps: function(nextProps) {
-      this.setState({
-        selectedPacket: this.props.selectedPacket
-      });
-    },
+  componentWillReceiveProps: function(nextProps) {
+    this.setState({
+      selectedPacket: this.props.selectedPacket
+    });
+  },
 
-    render: function() {
-      var selectedPacket = this.state.selectedPacket || this.props.selectedPacket;
+  render: function() {
+    var selectedPacket = this.state.selectedPacket || this.props.selectedPacket;
 
-      return (
-        DIV({className: "details editor"},
-            PacketEditorToolbar({
-              onClear: this.onClear,
-              onSend: this.onSend,
-              onUndo: this.onUndo,
-              onRedo: this.onRedo,
-              isUndoEnabled: true,
-              isRedoEnabled: true
-            }),
-            TreeEditorView({
-              ref: "editor",
-              key: "packet-editor",
-              data: selectedPacket && selectedPacket.to ? selectedPacket : null,
-              defaultData: this.state.defaultData
-            })
-           )
-      );
-    },
+    return (
+      DIV({className: "details editor"},
+          PacketEditorToolbar({
+            onClear: this.onClear,
+            onSend: this.onSend,
+            onUndo: this.onUndo,
+            onRedo: this.onRedo,
+            isUndoEnabled: true,
+            isRedoEnabled: true
+          }),
+          TreeEditorView({
+            ref: "editor",
+            key: "packet-editor",
+            data: selectedPacket && selectedPacket.to ? selectedPacket : null,
+            defaultData: this.state.defaultData
+          })
+         )
+    );
+  },
 
-    onUndo: function() {
-      this.refs.editor.undo();
-    },
+  onUndo: function() {
+    this.refs.editor.undo();
+  },
 
-    onRedo: function() {
-      this.refs.editor.redo();
-    },
+  onRedo: function() {
+    this.refs.editor.redo();
+  },
 
-    onClear: function() {
-      this.refs.editor.clearData();
-    },
+  onClear: function() {
+    this.refs.editor.clearData();
+  },
 
-    onSend: function() {
-      this.props.actions.send(this.refs.editor.getData());
-    }
-  });
+  onSend: function() {
+    this.props.actions.send(this.refs.editor.getData());
+  }
+});
 
-  // Exports from this module
-  exports.PacketEditor = React.createFactory(PacketEditor);
-
+// Exports from this module
+exports.PacketEditor = React.createFactory(PacketEditor);
 
 });

--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -41,7 +41,6 @@ var PacketsSidebar = React.createClass({
         ),
         TabPane({eventKey: 2, tab: "Send Packet"},
           PacketEditor({
-            selectedPacket: this.props.selectedPacket,
             actions: this.props.actions
           })
         )

--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -27,9 +27,35 @@ var PacketsSidebar = React.createClass({
 
   displayName: "PacketsSidebar",
 
+  getInitialState: function() {
+    return {
+      activeKey: 1
+    }
+  },
+
+  onTabSelected: function(key) {
+    this.setState({
+      activeKey: key
+    })
+  },
+
+  componentWillReceiveProps: function(nextProps) {
+    // reset activeKey to the "Packet" Detail sidebar
+    // when the parent component pass a new selectedPacket
+    if (nextProps.selectedPacket !== this.selectedPacket) {
+      this.setState({
+        activeKey: 1
+      });
+    }
+  },
+
   render: function() {
     return (
-      TabbedArea({className: "sideBarTabbedArea", animation: false},
+      TabbedArea({
+        className: "sideBarTabbedArea", animation: false,
+        activeKey: this.state.activeKey,
+        onSelect: this.onTabSelected
+      },
         TabPane({eventKey: 1, tab: "Packet Details"},
           PacketDetails({selectedPacket: this.props.selectedPacket})
         ),

--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -27,12 +27,6 @@ var PacketsSidebar = React.createClass({
 
   displayName: "PacketsSidebar",
 
-  getInitialState: function() {
-    return {
-      selectedPacket: null
-    };
-  },
-
   render: function() {
     return (
       TabbedArea({className: "sideBarTabbedArea", animation: false},

--- a/data/inspector/components/tree-editor-view.js
+++ b/data/inspector/components/tree-editor-view.js
@@ -1,6 +1,7 @@
 /* See license.txt for terms of usage */
 
 define(function(require, exports, module) {
+
 // Dependencies
 const React = require("react");
 const ReactBootstrap = require("react-bootstrap");
@@ -9,12 +10,18 @@ const Immutable = require("immutable");
 // Firebug SDK
 const { Reps } = require("reps/repository");
 
-// Shortcuts
+// Constants
 const { UL, LI, SPAN, DIV, I,
         TABLE, TBODY, THEAD, TFOOT, TR, TD,
         INPUT, TEXTAREA } = Reps.DOM;
 
+/**
+ * @template This template represents an editable
+ * tree view
+ */
 var TreeEditorView = React.createClass({
+/** @lends TreeEEditorView */
+
   displayName: "TreeEditorView",
 
   clearData: function() {
@@ -414,8 +421,15 @@ exports.TreeEditorView = React.createFactory(TreeEditorView);
 
 // non-exported React components
 
+/**
+ * @template This template represents a row which creates a new
+ * field in a defined key path
+ */
 var TableRowNewField = React.createFactory(React.createClass({
+/** @lends TableRowNewField */
+
   displayName: "TableRowNewField",
+
   getInitialState: function() {
     return {
       valid: true
@@ -470,7 +484,13 @@ var TableRowNewField = React.createFactory(React.createClass({
   }
 }));
 
+/**
+ * @template This template respesents a row for a field
+ * in a label editing state
+ */
 var TableRowEditingFieldLabel = React.createFactory(React.createClass({
+/** @lends TableRowEditingFieldLabel */
+
   displayName: "TableRowEditingFieldLabel",
 
   getInitialState: function() {
@@ -527,16 +547,25 @@ var TableRowEditingFieldLabel = React.createFactory(React.createClass({
   }
 }));
 
+/**
+ * @template This template respesents a row for a field
+ * in a value editing state
+ */
 var TableRowEditingFieldValue = React.createFactory(React.createClass({
+/** @lends TableRowEditingfieldValue */
+
   displayName: "TableRowEditingFieldValue",
+
   getInitialState: function() {
     return  {
       valid: true
     }
   },
+
   componentDidMount: function() {
     React.findDOMNode(this.refs.input).focus();
   },
+
   render: function() {
     var { level, label, value } = this.props;
 
@@ -549,6 +578,7 @@ var TableRowEditingFieldValue = React.createFactory(React.createClass({
 
     return TR({ className: rowClassName }, rowContent);
   },
+
   renderRowLabel: function() {
     var { keyPath, label, level } = this.props;
 
@@ -558,6 +588,7 @@ var TableRowEditingFieldValue = React.createFactory(React.createClass({
       style: { paddingLeft: 8 * level }
     }, SPAN({ className: 'memberLabel domLabel' }, label));
   },
+
   renderRowValue: function() {
     var { hasChildren, value, keyPath } = this.props;
     var { valid } = this.state;
@@ -600,7 +631,12 @@ var TableRowEditingFieldValue = React.createFactory(React.createClass({
   }
 }));
 
+/**
+ * @template This template respesenta a row for a field
+ * in non-editing state
+ */
 var TableRow = React.createFactory(React.createClass({
+/** @lends TableRow */
   displayName: "TableRow",
 
   render: function() {

--- a/data/inspector/components/tree-editor-view.js
+++ b/data/inspector/components/tree-editor-view.js
@@ -1,653 +1,656 @@
 /* See license.txt for terms of usage */
 
 define(function(require, exports, module) {
-  // Dependencies
-  const React = require("react");
-  const ReactBootstrap = require("react-bootstrap");
-  const Immutable = require("immutable");
+// Dependencies
+const React = require("react");
+const ReactBootstrap = require("react-bootstrap");
+const Immutable = require("immutable");
 
-  // Firebug SDK
-  const { Reps } = require("reps/repository");
+// Firebug SDK
+const { Reps } = require("reps/repository");
 
-  // Shortcuts
-  const { UL, LI, SPAN, DIV, I,
-          TABLE, TBODY, THEAD, TFOOT, TR, TD,
-          INPUT, TEXTAREA } = Reps.DOM;
+// Shortcuts
+const { UL, LI, SPAN, DIV, I,
+        TABLE, TBODY, THEAD, TFOOT, TR, TD,
+        INPUT, TEXTAREA } = Reps.DOM;
 
-  var TreeEditorView = React.createClass({
-    displayName: "TreeEditorView",
+var TreeEditorView = React.createClass({
+  displayName: "TreeEditorView",
 
-    clearData: function() {
-      var data = Immutable.fromJS(this.props.defaultData || {});
-      var newState = this.state.currentState.set("data", data);
-      var newHistory = !Immutable.is(this.state.currentState, newState) ?
-            this.generateUpdatedHistory(newState) :
-            this.state.stateHistory;
+  clearData: function() {
+    var data = Immutable.fromJS(this.props.defaultData || {});
+    var newState = this.state.currentState.set("data", data);
+    var newHistory = !Immutable.is(this.state.currentState, newState) ?
+          this.generateUpdatedHistory(newState) :
+          this.state.stateHistory;
+
+    this.setState({
+      currentState: newState,
+      stateHistory: newHistory
+    });
+  },
+
+  getData: function() {
+    return this.state.currentState.get("data").toJSON();
+  },
+
+  undo: function() {
+    if (this.hasUndo()) {
+      var index = this.state.stateHistory.get("index");
+      var newHistory = this.state.stateHistory.set("index", index - 1);
+      var newState = this.state.stateHistory.getIn(["history", index - 1]);
 
       this.setState({
         currentState: newState,
         stateHistory: newHistory
-      });
-    },
-
-    getData: function() {
-      return this.state.currentState.get("data").toJSON();
-    },
-
-    undo: function() {
-      if (this.hasUndo()) {
-        var index = this.state.stateHistory.get("index");
-        var newHistory = this.state.stateHistory.set("index", index - 1);
-        var newState = this.state.stateHistory.getIn(["history", index - 1]);
-
-        this.setState({
-          currentState: newState,
-          stateHistory: newHistory
-        })
-      }
-    },
-    redo: function() {
-      if (this.hasRedo()) {
-        var index = this.state.stateHistory.get("index");
-        var newHistory = this.state.stateHistory.set("index", index + 1);
-        var newState = this.state.stateHistory.getIn(["history", index + 1]);
-
-        this.setState({
-          currentState: newState,
-          stateHistory: newHistory
-        })
-      }
-    },
-    hasUndo: function() {
-      var size = this.state.stateHistory.get("history").size;
-      var index = this.state.stateHistory.get("index");
-
-      if (size > 1 && index > 0) {
-        return true;
-      }
-
-      return false;
-    },
-    hasRedo: function() {
-      var size = this.state.stateHistory.get("history").size;
-      var index = this.state.stateHistory.get("index");
-
-      if (size > 1 && index < size - 1) {
-        return true;
-      }
-
-      return false;
-    },
-
-    generateUpdatedHistory: function(newState) {
-      return this.state.stateHistory.withMutations(function(v) {
-        v.update('history', (history) => {
-          // TODO: configurable history size
-          if (history.size >= 16) {
-            return history.skip(1).push(newState);
-          } else {
-            return history.push(newState);
-          }
-        });
-        v.set('index', v.get('history').size - 1);
       })
-    },
+    }
+  },
+  redo: function() {
+    if (this.hasRedo()) {
+      var index = this.state.stateHistory.get("index");
+      var newHistory = this.state.stateHistory.set("index", index + 1);
+      var newState = this.state.stateHistory.getIn(["history", index + 1]);
 
-    propsToState: function(nextProps) {
-      nextProps = nextProps || {};
-      var data = nextProps.data;
+      this.setState({
+        currentState: newState,
+        stateHistory: newHistory
+      })
+    }
+  },
+  hasUndo: function() {
+    var size = this.state.stateHistory.get("history").size;
+    var index = this.state.stateHistory.get("index");
 
-      var currentState, stateHistory;
+    if (size > 1 && index > 0) {
+      return true;
+    }
 
-      // no previous state or new data set
-      if (!this.state || data) {
-        if (!data) {
-          data = nextProps.defaultData || {};
+    return false;
+  },
+  hasRedo: function() {
+    var size = this.state.stateHistory.get("history").size;
+    var index = this.state.stateHistory.get("index");
+
+    if (size > 1 && index < size - 1) {
+      return true;
+    }
+
+    return false;
+  },
+
+  generateUpdatedHistory: function(newState) {
+    return this.state.stateHistory.withMutations(function(v) {
+      v.update('history', (history) => {
+        // TODO: configurable history size
+        if (history.size >= 16) {
+          return history.skip(1).push(newState);
+        } else {
+          return history.push(newState);
         }
+      });
+      v.set('index', v.get('history').size - 1);
+    })
+  },
 
-        currentState = Immutable.fromJS({
-          data: data,
-          openedKeyPaths: {},
-          editingKeyPath: {}
-        });
-      } else {
-        currentState = this.state.currentState;
+  propsToState: function(nextProps) {
+    nextProps = nextProps || {};
+    var data = nextProps.data;
+
+    var currentState, stateHistory;
+
+    // no previous state or new data set
+    if (!this.state || data) {
+      if (!data) {
+        data = nextProps.defaultData || {};
       }
 
-      // no previous state or no stateHistory
-      if (!this.state || !this.state.stateHistory) {
-        stateHistory = Immutable.fromJS({
-          history: [currentState],
-          index: 0
-        });
-      } else {
-        stateHistory = this.state.stateHistory
-      }
+      currentState = Immutable.fromJS({
+        data: data,
+        openedKeyPaths: {},
+        editingKeyPath: {}
+      });
+    } else {
+      currentState = this.state.currentState;
+    }
 
-      return {
-        currentState: currentState,
-        stateHistory: stateHistory
-      };
-    },
+    // no previous state or no stateHistory
+    if (!this.state || !this.state.stateHistory) {
+      stateHistory = Immutable.fromJS({
+        history: [currentState],
+        index: 0
+      });
+    } else {
+      stateHistory = this.state.stateHistory
+    }
 
-    getInitialState: function() {
-      return this.propsToState(this.props);
-    },
+    return {
+      currentState: currentState,
+      stateHistory: stateHistory
+    };
+  },
 
-    componentWillReceiveProps: function(nextProps) {
-      this.setState(this.propsToState(nextProps));
-    },
+  getInitialState: function() {
+    return this.propsToState(this.props);
+  },
 
-    render: function() {
-      return (
-        TABLE({
-          className: "domTable editable",
-          cellPadding: 0, cellSpacing: 0
-        }, TBODY({}, this.renderTableRows()))
-      );
-    },
+  componentWillReceiveProps: function(nextProps) {
+    this.setState(this.propsToState(nextProps));
+  },
 
-    renderTableRows: function() {
-      var rootValue = this.state ? this.state.currentState.get("data") : null;
-      var rows = rootValue ?
-            this.flattenTreeValue(-1, "data", rootValue ) : [];
+  render: function() {
+    return (
+      TABLE({
+        className: "domTable editable",
+        cellPadding: 0, cellSpacing: 0
+      }, TBODY({}, this.renderTableRows()))
+    );
+  },
 
-      return rows.reduce((acc, row) => {
-        var {
-          level, key, value, keyPath,
-          opened, editing, hasChildren, newField
-        } = row;
+  renderTableRows: function() {
+    var rootValue = this.state ? this.state.currentState.get("data") : null;
+    var rows = rootValue ?
+          this.flattenTreeValue(-1, "data", rootValue ) : [];
 
-        if (newField) {
-          acc.push(TableRowNewField({
-            level: level,
-            key: keyPath.join("-") +"_newField",
-            onSubmit: (newKey, cancel) => {
-              this.onNewField(keyPath, newKey, cancel);
-            }
-          }));
+    return rows.reduce((acc, row) => {
+      var {
+        level, key, value, keyPath,
+        opened, editing, hasChildren, newField
+      } = row;
 
-          return acc;
-        }
-
-        if (editing == "label") {
-          acc.push(TableRowEditingFieldLabel({
-            key: keyPath.join("-") + "_editingLabel",
-            level: level, label: key, keyPath: keyPath,
-            hasChildren: hasChildren, value: value,
-            validation: (value) => {
-              // TODO: validator
-              return true;
-            },
-            autocompletion: (value) => {
-              // TODO: auto completion
-              return [];
-            },
-            onSubmit: (newKey, cancel) => {
-              this.onStopEditingFieldLabel(keyPath, key, newKey, cancel);
-            }
-          }));
-
-          return acc;
-        }
-
-        if (editing == "value") {
-          acc.push(TableRowEditingFieldValue({
-            key: keyPath.join("-") + "_editingValue",
-            level: level, label: key, keyPath: keyPath,
-            hasChildren: hasChildren, value: value,
-            validation: (value) => {
-              // TODO: add support to custom validators
-              var valid;
-
-              try {
-                JSON.parse(value);
-                valid = true;
-              } catch(e) {
-                valid = false;
-              }
-
-              return valid;
-            },
-            autocompletion: (value) => {
-              // TODO: auto completion
-              return [];
-            },
-            onSubmit: (newValue, cancel) => {
-              this.onStopEditingFieldValue(keyPath, value, JSON.parse(newValue), cancel);
-            }
-          }));
-
-          return acc;
-        }
-
-        acc.push(TableRow({
-          key: keyPath.join("-"), value: value,
-          level: level, label: key, keyPath: keyPath,
-          hasChildren: hasChildren, opened: opened,
-          onRowLabelClick: this.onToggleOpenField,
-          onRowLabelDblClick: this.onStartEditingFieldLabel,
-          onRowValueClick: this.onStartEditingFieldValue,
-          onRowRemoveClick: this.onRemoveField
+      if (newField) {
+        acc.push(TableRowNewField({
+          level: level,
+          key: keyPath.join("-") +"_newField",
+          onSubmit: (newKey, cancel) => {
+            this.onNewField(keyPath, newKey, cancel);
+          }
         }));
 
         return acc;
-      }, [])
-    },
-
-    onNewField: function(keyPath, key, cancel) {
-      var fullKeyPath = ["data"].concat(keyPath, key);
-
-      if (this.state.currentState.hasIn(fullKeyPath)) {
-        // nop if the key already exists
-        return;
       }
 
-      var newState = !cancel ?
-            this.state.currentState.setIn(fullKeyPath, undefined) :
-            this.state.currentState;
-
-      var newHistory = !cancel ?
-            this.generateUpdatedHistory(newState) :
-            this.state.stateHistory;
-
-      this.setState({
-        currentState: newState,
-        stateHistory: newHistory
-      });
-    },
-
-    onRemoveField: function(keyPath) {
-      var fullKeyPath = ["data"].concat(keyPath);
-
-      if (!this.state.currentState.hasIn(fullKeyPath)) {
-        // nop if the key doesn't exists
-        return;
-      }
-
-      var newState = this.state.currentState.deleteIn(fullKeyPath);
-
-      var newHistory = this.generateUpdatedHistory(newState);
-
-      this.setState({
-        currentState: newState,
-        stateHistory: newHistory
-      });
-    },
-
-    onToggleOpenField: function(keyPath, label) {
-      // toggle open/close tree view level
-      var newState = this.state.currentState.updateIn(
-        ["openedKeyPaths"].concat(keyPath),
-        (value) => {
-          if (value) {
-            return null;
-          } else {
-            return Immutable.fromJS({});
+      if (editing == "label") {
+        acc.push(TableRowEditingFieldLabel({
+          key: keyPath.join("-") + "_editingLabel",
+          level: level, label: key, keyPath: keyPath,
+          hasChildren: hasChildren, value: value,
+          validation: (value) => {
+            // TODO: validator
+            return true;
+          },
+          autocompletion: (value) => {
+            // TODO: auto completion
+            return [];
+          },
+          onSubmit: (newKey, cancel) => {
+            this.onStopEditingFieldLabel(keyPath, key, newKey, cancel);
           }
-        });
+        }));
 
-      this.setState({
-        currentState: newState
-      });
-    },
-
-    onStartEditingFieldLabel: function(keyPath, label) {
-      if (this.state.currentState.get("editingKeyPath").size > 0) {
-        // nop if there's aleady an editing key path active
-        return;
+        return acc;
       }
 
-      // start editing label on key path
-      var newState = this.state.currentState.setIn(
-        ["editingKeyPath"].concat(keyPath),
-        "label");
+      if (editing == "value") {
+        acc.push(TableRowEditingFieldValue({
+          key: keyPath.join("-") + "_editingValue",
+          level: level, label: key, keyPath: keyPath,
+          hasChildren: hasChildren, value: value,
+          validation: (value) => {
+            // TODO: add support to custom validators
+            var valid;
 
-      this.setState({
-        currentState: newState
-      });
-    },
+            try {
+              JSON.parse(value);
+              valid = true;
+            } catch(e) {
+              valid = false;
+            }
 
-    onStopEditingFieldLabel: function(keyPath, oldKey, newKey, cancel) {
-      // start editing label on key path
-      var parentKeyPath = keyPath.slice(0, -1);
-      var changed = oldKey !== newKey;
+            return valid;
+          },
+          autocompletion: (value) => {
+            // TODO: auto completion
+            return [];
+          },
+          onSubmit: (newValue, cancel) => {
+            this.onStopEditingFieldValue(keyPath, value, JSON.parse(newValue), cancel);
+          }
+        }));
 
-      var newState = this.state.currentState.withMutations((state) => {
-        state.updateIn(["editingKeyPath"], (v) => v.clear());
-        if (!cancel && changed) {
-          var value = state.getIn(["data"].concat(keyPath));
-          state.deleteIn(["data"].concat(keyPath));
-          state.setIn(["data"].concat(parentKeyPath, newKey), value);
-        }
-      });
-
-      var newHistory = (!cancel && changed) ?
-            this.generateUpdatedHistory(newState) :
-            this.state.stateHistory;
-
-      this.setState({
-        currentState: newState,
-        stateHistory: newHistory
-      });
-
-    },
-
-    onStartEditingFieldValue: function(keyPath, value) {
-      if (this.state.currentState.get("editingKeyPath").size > 0) {
-        // nop if there's aleady an editing key path active
-        return;
+        return acc;
       }
 
-      // start editing value on key path
-      var newState = this.state.currentState.setIn(
-        ["editingKeyPath"].concat(keyPath),
-        "value");
+      acc.push(TableRow({
+        key: keyPath.join("-"), value: value,
+        level: level, label: key, keyPath: keyPath,
+        hasChildren: hasChildren, opened: opened,
+        onRowLabelClick: this.onToggleOpenField,
+        onRowLabelDblClick: this.onStartEditingFieldLabel,
+        onRowValueClick: this.onStartEditingFieldValue,
+        onRowRemoveClick: this.onRemoveField
+      }));
 
-      this.setState({
-        currentState: newState
-      });
-    },
+      return acc;
+    }, [])
+  },
 
-    onStopEditingFieldValue: function(keyPath, oldValue, newValue, cancel) {
-      // stop editing value on key path
-      var parentKeyPath = keyPath.slice(0, -1);
-      var value = Immutable.fromJS(newValue);
-      var changed = !Immutable.is(oldValue, value);
+  onNewField: function(keyPath, key, cancel) {
+    var fullKeyPath = ["data"].concat(keyPath, key);
 
-      var newState = this.state.currentState.withMutations((state) => {
-        state.updateIn(["editingKeyPath"], (v) => v.clear());
-        if (!cancel && changed) {
-          state.setIn(["data"].concat(keyPath), value);
-        }
-      });
-
-      var newHistory = (!cancel && changed) ?
-            this.generateUpdatedHistory(newState) :
-            this.state.stateHistory;
-
-      this.setState({
-        currentState: newState,
-        stateHistory: newHistory
-      });
-
-    },
-
-    flattenTreeValue: function (level, key, value, keyPath) {
-      keyPath = keyPath || [];
-
-      var openedKeyPaths = this.state.currentState.get("openedKeyPaths");
-      var editingKeyPath = this.state.currentState.get("editingKeyPath");
-
-      var res = [];
-      var hasChildren = (
-        value instanceof Immutable.List ||
-          value instanceof Immutable.Map
-      );
-
-      var opened = hasChildren && openedKeyPaths.getIn(keyPath);
-      var editing = editingKeyPath.getIn(keyPath);
-
-      if (level >= 0) {  // skip the fake root data object level
-        res.push({ key: key, level: level, value: value,
-                   opened: opened, editing: editing,
-                   keyPath: keyPath, hasChildren: hasChildren});
-      }
-
-      if (level == -1 || (opened && !editing) || (editing && editing.size > 0)) {
-        res.push({ newField: true, level: level + 1, keyPath: keyPath });
-
-        value.forEach((value, subkey) => {
-          res = res.concat(
-            this.flattenTreeValue(level + 1, subkey, value,
-                                  keyPath.concat(subkey))
-          );
-        });
-      }
-
-      return res;
+    if (this.state.currentState.hasIn(fullKeyPath)) {
+      // nop if the key already exists
+      return;
     }
-  });
 
-  // Exports from this module
-  exports.TreeEditorView = React.createFactory(TreeEditorView);
+    var newState = !cancel ?
+          this.state.currentState.setIn(fullKeyPath, undefined) :
+          this.state.currentState;
 
-  var TableRowNewField = React.createFactory(React.createClass({
-    displayName: "TableRowNewField",
-    getInitialState: function() {
-      return {
-        valid: true
-      }
-    },
+    var newHistory = !cancel ?
+          this.generateUpdatedHistory(newState) :
+          this.state.stateHistory;
 
-    render: function() {
-      var { level } = this.props;
+    this.setState({
+      currentState: newState,
+      stateHistory: newHistory
+    });
+  },
 
-      var rowClassName = "memberRow newRow";
+  onRemoveField: function(keyPath) {
+    var fullKeyPath = ["data"].concat(keyPath);
 
-      var inputEl = INPUT({
-        placeholder: "New...",
-        onKeyUp: this.onKeyUp
-      });
-
-      return TR({ className: rowClassName }, [
-        TD({
-          key: 'new-label',
-          className: "memberLabelCell",
-          colSpan: 2,
-          style: { paddingLeft: 18 + (8 * level) }
-        }, inputEl)
-      ]);
-    },
-
-    onChange: function(event) {
-      var { valid } = this.state;
-
-      valid = this.props.validation ?
-        this.props.validation(event.target.value) :
-        true
-
-      this.setState({valid: valid});
-    },
-
-    onKeyUp: function(event) {
-      var { valid } = this.state;
-
-      if(valid && event.which == 13) {
-
-        if (typeof this.props.onSubmit == "function") {
-          // submit
-          this.props.onSubmit(event.target.value);
-        }
-        event.target.value = null;
-      } else if (event.which == 27) {
-        // cancel
-        this.props.onSubmit(event.target.value, true);
-        event.target.value = null;
-      }
+    if (!this.state.currentState.hasIn(fullKeyPath)) {
+      // nop if the key doesn't exists
+      return;
     }
-  }));
 
-  var TableRowEditingFieldLabel = React.createFactory(React.createClass({
-    displayName: "TableRowEditingFieldLabel",
+    var newState = this.state.currentState.deleteIn(fullKeyPath);
 
-    getInitialState: function() {
-      return {
-        valid: true
-      }
-    },
+    var newHistory = this.generateUpdatedHistory(newState);
 
-    componentDidMount: function() {
-      React.findDOMNode(this.refs.input).focus();
-    },
+    this.setState({
+      currentState: newState,
+      stateHistory: newHistory
+    });
+  },
 
-    render: function() {
-      var { level, label } = this.props;
-
-      var rowClassName = "memberRow newRow";
-
-      var inputEl = INPUT({
-        ref: 'input',
-        defaultValue: label,
-        onKeyUp: this.onKeyUp
+  onToggleOpenField: function(keyPath, label) {
+    // toggle open/close tree view level
+    var newState = this.state.currentState.updateIn(
+      ["openedKeyPaths"].concat(keyPath),
+      (value) => {
+        if (value) {
+          return null;
+        } else {
+          return Immutable.fromJS({});
+        }
       });
 
-      return TR({ className: rowClassName }, [
-        TD({
-          key: 'new-label',
-          className: "memberLabelCell",
-          colSpan: 2,
-          style: { paddingLeft: 18 + (8 * level) }
-        }, inputEl)
-      ]);
-    },
+    this.setState({
+      currentState: newState
+    });
+  },
 
-    onChange: function(event) {
-      var { valid } = this.state;
+  onStartEditingFieldLabel: function(keyPath, label) {
+    if (this.state.currentState.get("editingKeyPath").size > 0) {
+      // nop if there's aleady an editing key path active
+      return;
+    }
 
-      valid = this.props.validation ?
-        this.props.validation(event.target.value) :
-        true
+    // start editing label on key path
+    var newState = this.state.currentState.setIn(
+      ["editingKeyPath"].concat(keyPath),
+      "label");
 
-      this.setState({valid: valid});
-    },
+    this.setState({
+      currentState: newState
+    });
+  },
 
-    onKeyUp: function(event) {
-      var { valid } = this.state;
+  onStopEditingFieldLabel: function(keyPath, oldKey, newKey, cancel) {
+    // start editing label on key path
+    var parentKeyPath = keyPath.slice(0, -1);
+    var changed = oldKey !== newKey;
 
-      if(valid && event.which == 13) {
+    var newState = this.state.currentState.withMutations((state) => {
+      state.updateIn(["editingKeyPath"], (v) => v.clear());
+      if (!cancel && changed) {
+        var value = state.getIn(["data"].concat(keyPath));
+        state.deleteIn(["data"].concat(keyPath));
+        state.setIn(["data"].concat(parentKeyPath, newKey), value);
+      }
+    });
+
+    var newHistory = (!cancel && changed) ?
+          this.generateUpdatedHistory(newState) :
+          this.state.stateHistory;
+
+    this.setState({
+      currentState: newState,
+      stateHistory: newHistory
+    });
+
+  },
+
+  onStartEditingFieldValue: function(keyPath, value) {
+    if (this.state.currentState.get("editingKeyPath").size > 0) {
+      // nop if there's aleady an editing key path active
+      return;
+    }
+
+    // start editing value on key path
+    var newState = this.state.currentState.setIn(
+      ["editingKeyPath"].concat(keyPath),
+      "value");
+
+    this.setState({
+      currentState: newState
+    });
+  },
+
+  onStopEditingFieldValue: function(keyPath, oldValue, newValue, cancel) {
+    // stop editing value on key path
+    var parentKeyPath = keyPath.slice(0, -1);
+    var value = Immutable.fromJS(newValue);
+    var changed = !Immutable.is(oldValue, value);
+
+    var newState = this.state.currentState.withMutations((state) => {
+      state.updateIn(["editingKeyPath"], (v) => v.clear());
+      if (!cancel && changed) {
+        state.setIn(["data"].concat(keyPath), value);
+      }
+    });
+
+    var newHistory = (!cancel && changed) ?
+          this.generateUpdatedHistory(newState) :
+          this.state.stateHistory;
+
+    this.setState({
+      currentState: newState,
+      stateHistory: newHistory
+    });
+
+  },
+
+  flattenTreeValue: function (level, key, value, keyPath) {
+    keyPath = keyPath || [];
+
+    var openedKeyPaths = this.state.currentState.get("openedKeyPaths");
+    var editingKeyPath = this.state.currentState.get("editingKeyPath");
+
+    var res = [];
+    var hasChildren = (
+      value instanceof Immutable.List ||
+        value instanceof Immutable.Map
+    );
+
+    var opened = hasChildren && openedKeyPaths.getIn(keyPath);
+    var editing = editingKeyPath.getIn(keyPath);
+
+    if (level >= 0) {  // skip the fake root data object level
+      res.push({ key: key, level: level, value: value,
+                 opened: opened, editing: editing,
+                 keyPath: keyPath, hasChildren: hasChildren});
+    }
+
+    if (level == -1 || (opened && !editing) || (editing && editing.size > 0)) {
+      res.push({ newField: true, level: level + 1, keyPath: keyPath });
+
+      value.forEach((value, subkey) => {
+        res = res.concat(
+          this.flattenTreeValue(level + 1, subkey, value,
+                                keyPath.concat(subkey))
+        );
+      });
+    }
+
+    return res;
+  }
+});
+
+// Exports from this module
+exports.TreeEditorView = React.createFactory(TreeEditorView);
+
+// non-exported React components
+
+var TableRowNewField = React.createFactory(React.createClass({
+  displayName: "TableRowNewField",
+  getInitialState: function() {
+    return {
+      valid: true
+    }
+  },
+
+  render: function() {
+    var { level } = this.props;
+
+    var rowClassName = "memberRow newRow";
+
+    var inputEl = INPUT({
+      placeholder: "New...",
+      onKeyUp: this.onKeyUp
+    });
+
+    return TR({ className: rowClassName }, [
+      TD({
+        key: 'new-label',
+        className: "memberLabelCell",
+        colSpan: 2,
+        style: { paddingLeft: 18 + (8 * level) }
+      }, inputEl)
+    ]);
+  },
+
+  onChange: function(event) {
+    var { valid } = this.state;
+
+    valid = this.props.validation ?
+      this.props.validation(event.target.value) :
+      true
+
+    this.setState({valid: valid});
+  },
+
+  onKeyUp: function(event) {
+    var { valid } = this.state;
+
+    if(valid && event.which == 13) {
+
+      if (typeof this.props.onSubmit == "function") {
         // submit
         this.props.onSubmit(event.target.value);
-      } else if (event.which == 27) {
-        // cancel
-        this.props.onSubmit(event.target.value, true);
       }
+      event.target.value = null;
+    } else if (event.which == 27) {
+      // cancel
+      this.props.onSubmit(event.target.value, true);
+      event.target.value = null;
     }
-  }));
+  }
+}));
 
-  var TableRowEditingFieldValue = React.createFactory(React.createClass({
-    displayName: "TableRowEditingFieldValue",
-    getInitialState: function() {
-      return  {
-        valid: true
-      }
-    },
-    componentDidMount: function() {
-      React.findDOMNode(this.refs.input).focus();
-    },
-    render: function() {
-      var { level, label, value } = this.props;
+var TableRowEditingFieldLabel = React.createFactory(React.createClass({
+  displayName: "TableRowEditingFieldLabel",
 
-      var rowClassName = "memberRow domRow editRow";
+  getInitialState: function() {
+    return {
+      valid: true
+    }
+  },
 
-      var rowContent = [
-        this.renderRowLabel(),
-        this.renderRowValue()
-      ]
+  componentDidMount: function() {
+    React.findDOMNode(this.refs.input).focus();
+  },
 
-      return TR({ className: rowClassName }, rowContent);
-    },
-    renderRowLabel: function() {
-      var { keyPath, label, level } = this.props;
+  render: function() {
+    var { level, label } = this.props;
 
-      return TD({
-        key: 'label',
+    var rowClassName = "memberRow newRow";
+
+    var inputEl = INPUT({
+      ref: 'input',
+      defaultValue: label,
+      onKeyUp: this.onKeyUp
+    });
+
+    return TR({ className: rowClassName }, [
+      TD({
+        key: 'new-label',
         className: "memberLabelCell",
-        style: { paddingLeft: 8 * level }
-      }, SPAN({ className: 'memberLabel domLabel' }, label));
-    },
-    renderRowValue: function() {
-      var { hasChildren, value, keyPath } = this.props;
-      var { valid } = this.state;
+        colSpan: 2,
+        style: { paddingLeft: 18 + (8 * level) }
+      }, inputEl)
+    ]);
+  },
 
-      var jsonValue = (value instanceof Immutable.Collection) ?
-            value.toJSON() : value;
+  onChange: function(event) {
+    var { valid } = this.state;
 
-      var inputEl = INPUT({
-        ref: 'input',
-        defaultValue: JSON.stringify(jsonValue),
-        onKeyUp: this.onKeyUp,
-        onChange: this.onChange,
-        className: valid ? "valid" : "invalid"
-      });
+    valid = this.props.validation ?
+      this.props.validation(event.target.value) :
+      true
 
-      return TD({ key: 'value', className: "memberValueCell" },
-                inputEl, I({}));
-    },
+    this.setState({valid: valid});
+  },
 
-    onChange: function(event) {
-      var { valid } = this.state;
+  onKeyUp: function(event) {
+    var { valid } = this.state;
 
-      valid = this.props.validation ?
-        this.props.validation(event.target.value) :
-        true
-
-      this.setState({valid: valid});
-    },
-
-    onKeyUp: function(event) {
-      var { valid } = this.state;
-
-      if(valid && event.which == 13) {
-        // submit
-        this.props.onSubmit(event.target.value);
-      } else if (event.which == 27) {
-        // cancel
-        this.props.onSubmit(event.target.value, true);
-      }
+    if(valid && event.which == 13) {
+      // submit
+      this.props.onSubmit(event.target.value);
+    } else if (event.which == 27) {
+      // cancel
+      this.props.onSubmit(event.target.value, true);
     }
-  }));
+  }
+}));
 
-  var TableRow = React.createFactory(React.createClass({
-    displayName: "TableRow",
-
-    render: function() {
-      var { hasChildren, opened } = this.props;
-
-      var rowClassName = "memberRow domRow";
-
-      if (hasChildren) {
-        rowClassName += " hasChildren";
-      }
-
-      if (opened) {
-        rowClassName += " opened";
-      }
-
-      var rowContent = [
-        this.renderRowLabel(),
-        this.renderRowValue()
-      ]
-
-      return TR({ className: rowClassName }, rowContent);
-    },
-
-    renderRowLabel: function() {
-      var { keyPath, label, level } = this.props;
-
-      return TD({
-        key: 'label',
-        className: "memberLabelCell",
-        style: { paddingLeft: 8 * level },
-        onDoubleClick: () => this.props.onRowLabelDblClick(keyPath, label),
-        onClick: () => this.props.onRowLabelClick(keyPath, label)
-      }, SPAN({ className: 'memberLabel domLabel' }, label));
-    },
-
-    renderRowValue: function() {
-      var { hasChildren, value, keyPath } = this.props;
-
-      var jsonValue = hasChildren ? value.toJSON() : value;
-
-      var valueSummary = Reps.getRep(jsonValue)({ object: jsonValue });
-
-      return TD({ key: 'value', className: "memberValueCell" },
-                SPAN({
-                  onClick: () => this.props.onRowValueClick(keyPath, value)
-                }, valueSummary),
-                I({ className: "closeButton",
-                    onClick: () => this.props.onRowRemoveClick(keyPath) })
-               );
+var TableRowEditingFieldValue = React.createFactory(React.createClass({
+  displayName: "TableRowEditingFieldValue",
+  getInitialState: function() {
+    return  {
+      valid: true
     }
-  }));
+  },
+  componentDidMount: function() {
+    React.findDOMNode(this.refs.input).focus();
+  },
+  render: function() {
+    var { level, label, value } = this.props;
+
+    var rowClassName = "memberRow domRow editRow";
+
+    var rowContent = [
+      this.renderRowLabel(),
+      this.renderRowValue()
+    ]
+
+    return TR({ className: rowClassName }, rowContent);
+  },
+  renderRowLabel: function() {
+    var { keyPath, label, level } = this.props;
+
+    return TD({
+      key: 'label',
+      className: "memberLabelCell",
+      style: { paddingLeft: 8 * level }
+    }, SPAN({ className: 'memberLabel domLabel' }, label));
+  },
+  renderRowValue: function() {
+    var { hasChildren, value, keyPath } = this.props;
+    var { valid } = this.state;
+
+    var jsonValue = (value instanceof Immutable.Collection) ?
+          value.toJSON() : value;
+
+    var inputEl = INPUT({
+      ref: 'input',
+      defaultValue: JSON.stringify(jsonValue),
+      onKeyUp: this.onKeyUp,
+      onChange: this.onChange,
+      className: valid ? "valid" : "invalid"
+    });
+
+    return TD({ key: 'value', className: "memberValueCell" },
+              inputEl, I({}));
+  },
+
+  onChange: function(event) {
+    var { valid } = this.state;
+
+    valid = this.props.validation ?
+      this.props.validation(event.target.value) :
+      true
+
+    this.setState({valid: valid});
+  },
+
+  onKeyUp: function(event) {
+    var { valid } = this.state;
+
+    if(valid && event.which == 13) {
+      // submit
+      this.props.onSubmit(event.target.value);
+    } else if (event.which == 27) {
+      // cancel
+      this.props.onSubmit(event.target.value, true);
+    }
+  }
+}));
+
+var TableRow = React.createFactory(React.createClass({
+  displayName: "TableRow",
+
+  render: function() {
+    var { hasChildren, opened } = this.props;
+
+    var rowClassName = "memberRow domRow";
+
+    if (hasChildren) {
+      rowClassName += " hasChildren";
+    }
+
+    if (opened) {
+      rowClassName += " opened";
+    }
+
+    var rowContent = [
+      this.renderRowLabel(),
+      this.renderRowValue()
+    ]
+
+    return TR({ className: rowClassName }, rowContent);
+  },
+
+  renderRowLabel: function() {
+    var { keyPath, label, level } = this.props;
+
+    return TD({
+      key: 'label',
+      className: "memberLabelCell",
+      style: { paddingLeft: 8 * level },
+      onDoubleClick: () => this.props.onRowLabelDblClick(keyPath, label),
+      onClick: () => this.props.onRowLabelClick(keyPath, label)
+    }, SPAN({ className: 'memberLabel domLabel' }, label));
+  },
+
+  renderRowValue: function() {
+    var { hasChildren, value, keyPath } = this.props;
+
+    var jsonValue = hasChildren ? value.toJSON() : value;
+
+    var valueSummary = Reps.getRep(jsonValue)({ object: jsonValue });
+
+    return TD({ key: 'value', className: "memberValueCell" },
+              SPAN({
+                onClick: () => this.props.onRowValueClick(keyPath, value)
+              }, valueSummary),
+              I({ className: "closeButton",
+                  onClick: () => this.props.onRowRemoveClick(keyPath) })
+             );
+  }
+}));
+
 });

--- a/data/inspector/components/tree-editor-view.js
+++ b/data/inspector/components/tree-editor-view.js
@@ -97,21 +97,32 @@ define(function(require, exports, module) {
       nextProps = nextProps || {};
       var data = nextProps.data;
 
-      // no data selected and no default data configured
-      if (!data) {
-        data = nextProps.defaultData || {};
+      var currentState, stateHistory;
+
+      // no previous state or new data set
+      if (!this.state || data) {
+        if (!data) {
+          data = nextProps.defaultData || {};
+        }
+
+        currentState = Immutable.fromJS({
+          data: data,
+          openedKeyPaths: {},
+          editingKeyPath: {}
+        });
+      } else {
+        currentState = this.state.currentState;
       }
 
-      var currentState = Immutable.fromJS({
-        data: data,
-        openedKeyPaths: {},
-        editingKeyPath: {}
-      });
-
-      var stateHistory = Immutable.fromJS({
-        history: [currentState],
-        index: 0
-      });
+      // no previous state or no stateHistory
+      if (!this.state || !this.state.stateHistory) {
+        stateHistory = Immutable.fromJS({
+          history: [currentState],
+          index: 0
+        });
+      } else {
+        stateHistory = this.state.stateHistory
+      }
 
       return {
         currentState: currentState,


### PR DESCRIPTION
This pull request fixes indentation and add proper JS docs on the packet-editor and tree-editor-view modules.

(The real change is composed of the last two commits, but it's based on the #24, so I'm going to rebase it once #24 will be merged)