### PR TITLE
Fix "switch to sidebar to Packet Details only on new selected packet"

### DIFF
--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -42,7 +42,7 @@ var PacketsSidebar = React.createClass({
   componentWillReceiveProps: function(nextProps) {
     // reset activeKey to the "Packet" Detail sidebar
     // when the parent component pass a new selectedPacket
-    if (nextProps.selectedPacket !== this.selectedPacket) {
+    if (nextProps.selected && (nextProps.selectedPacket !== this.selectedPacket)) {
       this.setState({
         activeKey: 1
       });


### PR DESCRIPTION
This change only switch the sidebar to Packet Details only when a new packet is selected

Previously it did change to the Packet Details even when the selected packet was ```null``` or
```undefined```