### PR TITLE
Fix typos in the PacketsSidebar componentWillReceiveProps

### DIFF
--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -42,7 +42,7 @@ var PacketsSidebar = React.createClass({
   componentWillReceiveProps: function(nextProps) {
     // reset activeKey to the "Packet" Detail sidebar
     // when the parent component pass a new selectedPacket
-    if (nextProps.selected && (nextProps.selectedPacket !== this.selectedPacket)) {
+    if (nextProps.selectedPacket && (nextProps.selectedPacket !== this.props.selectedPacket)) {
       this.setState({
         activeKey: 1
       });


### PR DESCRIPTION
This pull request fixes a couple of typos in the PacketsSidebar componentWillReceiveProps,
it should switch the sidebar to the PacketDetails only when a packet is selected.
(e.g. it should not switch to PacketDetails sidebar tab when we send a new Packet from the
PacketEditor sidebar tab) 