### PR TITLE
Feature: save and load packets store

### DIFF
--- a/chrome/locale/en-US/inspector.properties
+++ b/chrome/locale/en-US/inspector.properties
@@ -75,3 +75,10 @@ rdpInspector.label.Unpaused=Unpaused
 rdpInspector.label.MainProcess=Main Process
 rdpInspector.label.ChildProcess=Child Process
 rdpInspector.label.ActorsFactories=Actors Factories
+
+# LOCALIZATION NOTE
+# Labels for the drodown menus in the packets panel toolbar.
+rdpInspector.menu.File=File
+rdpInspector.menu.Options=Options
+rdpInspector.cmd.load=Load
+rdpInspector.cmd.save=Save

--- a/data/inspector/components/main-tabbed-area.js
+++ b/data/inspector/components/main-tabbed-area.js
@@ -56,19 +56,19 @@ var MainTabbedArea = React.createClass({
     var actors = Locale.$STR("rdpInspector.tab.Actors");
     var { error } = this.state;
 
-    return (DIV({},
-      error ? Alert({
-        bsStyle: "warning",
-        onDismiss: this.onErrorDismiss,
-        dismissAfter: 2000,
-        style: {
-          position: "absolute",
-          width: "100%",
-          zIndex: 999999
-        }
-      }, error.message) : null,
+    return (
       TabbedArea({className: "mainTabbedArea", defaultActiveKey: 1,
         animation: false, ref: "tabbedArea"},
+        error ? Alert({
+          bsStyle: "warning",
+          onDismiss: this.onErrorDismiss,
+          dismissAfter: 2000,
+          style: {
+            position: "absolute",
+            width: "100%",
+            zIndex: 999999
+          }
+        }, error.message) : null,
         TabPane({eventKey: 1, tab: packets},
           PacketsPanel({
             packets: this.state.packets,
@@ -89,7 +89,7 @@ var MainTabbedArea = React.createClass({
           })
         )
       )
-    ));
+    );
   }
 });
 

--- a/data/inspector/components/main-tabbed-area.js
+++ b/data/inspector/components/main-tabbed-area.js
@@ -17,6 +17,7 @@ const { SearchBox } = require("./search-box");
 // Constants
 const TabbedArea = React.createFactory(ReactBootstrap.TabbedArea);
 const TabPane = React.createFactory(ReactBootstrap.TabPane);
+const Alert = React.createFactory(ReactBootstrap.Alert);
 const { DIV } = Reps.DOM;
 
 /**
@@ -44,11 +45,28 @@ var MainTabbedArea = React.createClass({
     SearchBox.destroy(tabbedArea.querySelector(".nav-tabs"));
   },
 
+  onErrorDismiss: function() {
+    this.setState({
+      error: null
+    })
+  },
+
   render: function() {
     var packets = Locale.$STR("rdpInspector.tab.Packets");
     var actors = Locale.$STR("rdpInspector.tab.Actors");
+    var { error } = this.state;
 
-    return (
+    return (DIV({},
+      error ? Alert({
+        bsStyle: "warning",
+        onDismiss: this.onErrorDismiss,
+        dismissAfter: 2000,
+        style: {
+          position: "absolute",
+          width: "100%",
+          zIndex: 999999
+        }
+      }, error.message) : null,
       TabbedArea({className: "mainTabbedArea", defaultActiveKey: 1,
         animation: false, ref: "tabbedArea"},
         TabPane({eventKey: 1, tab: packets},
@@ -71,7 +89,7 @@ var MainTabbedArea = React.createClass({
           })
         )
       )
-    )
+    ));
   }
 });
 

--- a/data/inspector/components/packets-toolbar.js
+++ b/data/inspector/components/packets-toolbar.js
@@ -102,10 +102,13 @@ var PacketsToolbar = React.createClass({
 
   onLoadPacketsFromFile: function(event) {
     this.props.actions.loadPacketsFromFile();
+    this.refs.fileMenu.setDropdownState(false);
+
   },
 
   onSavePacketsFromFile: function(event) {
     this.props.actions.savePacketsToFile();
+    this.refs.fileMenu.setDropdownState(false);
   }
 });
 

--- a/data/inspector/components/packets-toolbar.js
+++ b/data/inspector/components/packets-toolbar.js
@@ -2,6 +2,7 @@
 /* globals Locale */
 
 define(function(require, exports, module) {
+
 "use strict";
 
 // ReactJS

--- a/data/inspector/components/packets-toolbar.js
+++ b/data/inspector/components/packets-toolbar.js
@@ -38,12 +38,14 @@ var PacketsToolbar = React.createClass({
 
     return (
       ButtonToolbar({className: "toolbar"},
-        DropdownButton({bsSize: "xsmall", title: "File"},
-          MenuItem({key: "fileLoad", onClick: this.onLoadPacketsFromFile }, "Load"),
-          MenuItem({key: "fileSave", onClick: this.onSavePacketsFromFile }, "Save")
+        DropdownButton({bsSize: "xsmall", ref: "fileMenu", title: Locale.$STR("rdpInspector.menu.File")},
+          MenuItem({key: "fileLoad", ref: "fileLoad", onClick: this.onLoadPacketsFromFile },
+            Locale.$STR("rdpInspector.cmd.load")),
+          MenuItem({key: "fileSave", ref: "fileSave", onClick: this.onSavePacketsFromFile },
+            Locale.$STR("rdpInspector.cmd.save"))
         ),
         DropdownButton({
-          bsSize: "xsmall", title: "Options",
+          bsSize: "xsmall", title: Locale.$STR("rdpInspector.menu.Options"),
           className: "pull-right", ref: "options"
         },
           MenuItem({key: "inlineDetails", onClick: this.onShowInlineDetails,

--- a/data/inspector/components/packets-toolbar.js
+++ b/data/inspector/components/packets-toolbar.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
+/* globals Locale */
 
 define(function(require, exports, module) {
+"use strict";
 
 // ReactJS
 var React = require("react");
@@ -35,7 +37,14 @@ var PacketsToolbar = React.createClass({
 
     return (
       ButtonToolbar({className: "toolbar"},
-        DropdownButton({bsSize: "xsmall", title: "Options", ref: "options"},
+        DropdownButton({bsSize: "xsmall", title: "File"},
+          MenuItem({key: "fileLoad", onClick: this.onLoadPacketsFromFile }, "Load"),
+          MenuItem({key: "fileSave", onClick: this.onSavePacketsFromFile }, "Save")
+        ),
+        DropdownButton({
+          bsSize: "xsmall", title: "Options",
+          className: "pull-right", ref: "options"
+        },
           MenuItem({key: "inlineDetails", onClick: this.onShowInlineDetails,
             checked: showInlineDetails},
             label
@@ -87,6 +96,14 @@ var PacketsToolbar = React.createClass({
   onPause: function(event) {
     this.props.actions.onPause();
   },
+
+  onLoadPacketsFromFile: function(event) {
+    this.props.actions.loadPacketsFromFile();
+  },
+
+  onSavePacketsFromFile: function(event) {
+    this.props.actions.savePacketsToFile();
+  }
 });
 
 // Exports from this module

--- a/data/inspector/main.js
+++ b/data/inspector/main.js
@@ -92,32 +92,11 @@ var actions = {
     }
   },
   loadPacketsFromFile: function() {
-    var input = document.createElement("input");
-    input.setAttribute("type", "file");
-    input.onchange = () => {
-      var reader = new FileReader();
-      reader.onload = () => {
-        try {
-          packetsStore.deserialize(reader.result);
-        } catch(e) {
-          theApp.setState({
-            error: {
-              message: "Error loading packets from file",
-              details: e
-            }
-          });
-        }
-      };
-      reader.readAsText(input.files[0]);
-    };
-    document.body.appendChild(input);
-    input.click();
-    document.body.removeChild(input);
+    postChromeMessage("load-from-file");
   },
   savePacketsToFile: function() {
     try {
-      var blob = new Blob([packetsStore.serialize()],
-                          { type: contentType });
+      var json = packetsStore.serialize();
     } catch(e) {
       theApp.setState({
         error: {
@@ -127,14 +106,12 @@ var actions = {
       });
       return;
     }
-
-    var contentType = "application/json";
-    var a = document.createElement("a");
-    a.setAttribute("href", window.URL.createObjectURL(blob));
-    a.setAttribute("download", "RDP-packets-dump.json");
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
+    
+    postChromeMessage("save-to-file", {
+      data: json,
+      contentType: "application/json",
+      filename: "RDP-packets-dump.json"
+    });
   }
 };
 

--- a/data/inspector/main.js
+++ b/data/inspector/main.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
+/* globals Locale, postChromeMessage */
 
 define(function(require, exports, module) {
+"use strict";
 
 // ReactJS
 var React = require("react");
@@ -87,6 +89,36 @@ var actions = {
     } else {
       packetsStore.appendMessage(Locale.$STR("rdpInspector.label.Unpaused"));
     }
+  },
+  loadPacketsFromFile: function() {
+    var input = document.createElement("input");
+    input.setAttribute("type", "file");
+    input.onchange = () => {
+      var reader = new FileReader();
+      reader.onload = () => {
+        try {
+          packetsStore.deserialize(reader.result);
+        } catch(e) {
+          console.log("ERROR", e);
+          throw e;
+        }
+      };
+      reader.readAsText(input.files[0]);
+    };
+    document.body.appendChild(input);
+    input.click();
+    document.body.removeChild(input);
+  },
+  savePacketsToFile: function() {
+    var contentType = "application/json";
+    var a = document.createElement("a");
+    var blob = new Blob([packetsStore.serialize()],
+                        { type: contentType });
+    a.setAttribute("href", window.URL.createObjectURL(blob));
+    a.setAttribute("download", "RDP-packets-dump.json");
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
   }
 };
 

--- a/data/inspector/main.js
+++ b/data/inspector/main.js
@@ -99,8 +99,12 @@ var actions = {
         try {
           packetsStore.deserialize(reader.result);
         } catch(e) {
-          console.log("ERROR", e);
-          throw e;
+          theApp.setState({
+            error: {
+              message: "Error loading packets from file",
+              details: e
+            }
+          });
         }
       };
       reader.readAsText(input.files[0]);
@@ -110,10 +114,21 @@ var actions = {
     document.body.removeChild(input);
   },
   savePacketsToFile: function() {
+    try {
+      var blob = new Blob([packetsStore.serialize()],
+                          { type: contentType });
+    } catch(e) {
+      theApp.setState({
+        error: {
+          message: "Error saving packets to file",
+          details: e
+        }
+      });
+      return;
+    }
+
     var contentType = "application/json";
     var a = document.createElement("a");
-    var blob = new Blob([packetsStore.serialize()],
-                        { type: contentType });
     a.setAttribute("href", window.URL.createObjectURL(blob));
     a.setAttribute("download", "RDP-packets-dump.json");
     document.body.appendChild(a);

--- a/data/inspector/main.js
+++ b/data/inspector/main.js
@@ -2,6 +2,7 @@
 /* globals Locale, postChromeMessage */
 
 define(function(require, exports, module) {
+
 "use strict";
 
 // ReactJS

--- a/data/inspector/packets-store.js
+++ b/data/inspector/packets-store.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
+/* globals Options */
 
 define(function(require, exports, module) {
+"use strict";
 
 // Constants
 const refreshTimeout = 200;
@@ -20,6 +22,12 @@ function PacketsStore(win, app) {
   this.clear();
 }
 
+const DUMP_FORMAT_VERSION = "rdp-inspector/packets-store/v1";
+const DUMP_FORMAT_KEYS = [
+  "packets", "summary",
+  "uniqueId", "removedPackets"
+];
+
 PacketsStore.prototype =
 /** @lends PacketsStore */
 {
@@ -35,7 +43,7 @@ PacketsStore.prototype =
       return;
     }
 
-    for (var i=0; i<packets.length; i++) {
+    for (var i = 0; i < packets.length; i++) {
       var packet = packets[i];
       this.appendPacket({
         type: packet.type,
@@ -73,10 +81,10 @@ PacketsStore.prototype =
     packet.id = ++this.uniqueId;
 
     // Collect statistics data.
-    if (packet.type == "send") {
+    if (packet.type === "send") {
       this.summary.data.sent += packet.size;
       this.summary.packets.sent += 1;
-    } else if (packet.type == "receive") {
+    } else if (packet.type === "receive") {
       this.summary.data.received += packet.size;
       this.summary.packets.received += 1;
     }
@@ -112,7 +120,7 @@ PacketsStore.prototype =
     var newState = {
       packets: this.packets,
       removedPackets: this.removedPackets
-    }
+    };
 
     // Default selection
     if (!this.app.state.selectedPacket) {
@@ -142,7 +150,7 @@ PacketsStore.prototype =
       },
       packets: {
         sent: 0,
-        received: 0,
+        received: 0
       }
     };
 
@@ -170,8 +178,40 @@ PacketsStore.prototype =
       time: new Date(),
       message: message
     }, true);
+  },
+
+  serialize: function() {
+    var data = {
+      "!format!": DUMP_FORMAT_VERSION
+    };
+    DUMP_FORMAT_KEYS.forEach((key) => {
+      data[key] = this[key];
+    });
+    return JSON.stringify(data);
+  },
+
+  deserialize: function(rawdata) {
+    var data = JSON.parse(rawdata, (k, v) => {
+      switch (k) {
+      case "time":
+        return new Date(v);
+      default:
+        return v;
+      }
+    });
+
+    if (data["!format!"] &&
+        data["!format!"] === DUMP_FORMAT_VERSION) {
+      DUMP_FORMAT_KEYS.forEach((key) => {
+        this[key] = data[key];
+      });
+    } else {
+      throw Error("Dump file format unrecognized");
+    }
+
+    this.refreshPackets(true);
   }
-}
+};
 
 // Exports from this module
 exports.PacketsStore = PacketsStore;

--- a/data/inspector/packets-store.js
+++ b/data/inspector/packets-store.js
@@ -19,6 +19,7 @@ function PacketsStore(win, app) {
   this.win.addEventListener("init-packet-list", this.onInitialize.bind(this));
   this.win.addEventListener("send-packet", this.onSendPacket.bind(this));
   this.win.addEventListener("receive-packet", this.onReceivePacket.bind(this));
+  this.win.addEventListener("loaded-packet-list-file", this.onLoadedPacketListFile.bind(this));
 
   this.clear();
 }
@@ -32,6 +33,18 @@ const DUMP_FORMAT_KEYS = [
 PacketsStore.prototype =
 /** @lends PacketsStore */
 {
+  onLoadedPacketListFile: function(event) {
+    try {
+      this.deserialize(event.data);
+    } catch(e) {
+      this.app.setState({
+        error: {
+          message: "Error loading packets from file",
+          details: e
+        }
+      });
+    }
+  },
   onInitialize: function(event) {
     var cache = JSON.parse(event.data);
 

--- a/data/inspector/packets-store.js
+++ b/data/inspector/packets-store.js
@@ -2,6 +2,7 @@
 /* globals Options */
 
 define(function(require, exports, module) {
+
 "use strict";
 
 // Constants

--- a/karma-tests/components/main-tabbed-area-spec.js
+++ b/karma-tests/components/main-tabbed-area-spec.js
@@ -2,6 +2,7 @@
 /* eslint-env jasmine */
 
 define(function (require) {
+
 "use strict";
 
 var React = require("react");

--- a/karma-tests/components/packets-toolbar-spec.js
+++ b/karma-tests/components/packets-toolbar-spec.js
@@ -1,0 +1,96 @@
+/* eslint-env jasmine */
+
+define(function (require) {
+"use strict";
+
+var React = require("react");
+var { TestUtils } = React.addons;
+
+var { PacketsToolbar } = require("components/packets-toolbar");
+var {
+  DropdownButton,
+  MenuItem
+} = require("react-bootstrap");
+
+var packetsToolbar = TestUtils.renderIntoDocument(PacketsToolbar({}));
+
+var ReactMatchers = require("karma-tests/custom-react-matchers");
+
+describe("PacketsToolbar", () => {
+  beforeAll(() => {
+    jasmine.addMatchers(ReactMatchers);
+  });
+
+  it("renders without errors", () => {
+    expect(packetsToolbar).toBeDefined();
+
+    expect(packetsToolbar.getDOMNode()).toBeDefined();
+  });
+
+  it("contains a 'File' DropdownButton", () => {
+    var instances = TestUtils.scryRenderedComponentsWithType(packetsToolbar,
+        DropdownButton);
+
+    var fileDropdowns = instances.filter((instance) => {
+      return instance.props.title === "File";
+    });
+    expect(instances.length).toBeGreaterThan(0);
+    expect(fileDropdowns.length).toBe(1);
+  });
+
+  describe("its File DropdownButton Menu", () => {
+    var fileMenu, menuItemsByLabel;
+    // spy actions that should be called
+    var actions = {
+      loadPacketsFromFile: jasmine.createSpy("loadPacketsFromFile"),
+      savePacketsToFile: jasmine.createSpy("savePacketsToFile")
+    };
+
+    beforeAll(() => {
+      packetsToolbar = TestUtils.renderIntoDocument(PacketsToolbar({
+        actions: actions
+      }));
+
+      // get a reference to the file menu
+      fileMenu = TestUtils.scryRenderedComponentsWithType(
+        packetsToolbar, DropdownButton
+      ).filter((instance) => {
+        return instance.props.title === "File";
+      })[0];
+
+      // collect menuItems in a map indexed by label
+      menuItemsByLabel = TestUtils.scryRenderedComponentsWithType(
+        fileMenu, MenuItem
+      ).reduce((acc, instance) => {
+        var { children } = instance.props;
+        acc[children] = !acc[children] ?
+          [ instance ] :
+          acc[children].push(instance);
+        return acc;
+      }, {});
+    });
+
+    it("contains a Load and Save MenuItems", () => {
+      // load and save menuitems should be defined
+      expect(menuItemsByLabel.Load).toBeDefined();
+      expect(menuItemsByLabel.Save).toBeDefined();
+      // they should not have any duplicates
+      expect(menuItemsByLabel.Load.length).toBe(1);
+      expect(menuItemsByLabel.Save.length).toBe(1);
+    });
+
+    it("calls props.actions.loadPacketsFromFile on Load clicks", () => {
+      var node = React.findDOMNode(menuItemsByLabel.Load[0]);
+      TestUtils.Simulate.click(node);
+      expect(actions.loadPacketsFromFile).toHaveBeenCalled();
+    });
+
+    it("calls props.actions.savePacketsFromFile on Save clicks", () => {
+      var node = React.findDOMNode(menuItemsByLabel.Save[0]);
+      TestUtils.Simulate.click(node);
+      expect(actions.savePacketsToFile).toHaveBeenCalled();
+    });
+  });
+
+});
+});

--- a/karma-tests/components/packets-toolbar-spec.js
+++ b/karma-tests/components/packets-toolbar-spec.js
@@ -29,18 +29,10 @@ describe("PacketsToolbar", () => {
   });
 
   it("contains a 'File' DropdownButton", () => {
-    var instances = TestUtils.scryRenderedComponentsWithType(packetsToolbar,
-        DropdownButton);
-
-    var fileDropdowns = instances.filter((instance) => {
-      return instance.props.title === "File";
-    });
-    expect(instances.length).toBeGreaterThan(0);
-    expect(fileDropdowns.length).toBe(1);
+    expect(packetsToolbar.refs.fileMenu).toBeDefined();
   });
 
   describe("its File DropdownButton Menu", () => {
-    var fileMenu, menuItemsByLabel;
     // spy actions that should be called
     var actions = {
       loadPacketsFromFile: jasmine.createSpy("loadPacketsFromFile"),
@@ -51,43 +43,22 @@ describe("PacketsToolbar", () => {
       packetsToolbar = TestUtils.renderIntoDocument(PacketsToolbar({
         actions: actions
       }));
-
-      // get a reference to the file menu
-      fileMenu = TestUtils.scryRenderedComponentsWithType(
-        packetsToolbar, DropdownButton
-      ).filter((instance) => {
-        return instance.props.title === "File";
-      })[0];
-
-      // collect menuItems in a map indexed by label
-      menuItemsByLabel = TestUtils.scryRenderedComponentsWithType(
-        fileMenu, MenuItem
-      ).reduce((acc, instance) => {
-        var { children } = instance.props;
-        acc[children] = !acc[children] ?
-          [ instance ] :
-          acc[children].push(instance);
-        return acc;
-      }, {});
     });
 
     it("contains a Load and Save MenuItems", () => {
       // load and save menuitems should be defined
-      expect(menuItemsByLabel.Load).toBeDefined();
-      expect(menuItemsByLabel.Save).toBeDefined();
-      // they should not have any duplicates
-      expect(menuItemsByLabel.Load.length).toBe(1);
-      expect(menuItemsByLabel.Save.length).toBe(1);
+      expect(packetsToolbar.refs.fileLoad).toBeDefined();
+      expect(packetsToolbar.refs.fileSave).toBeDefined();
     });
 
     it("calls props.actions.loadPacketsFromFile on Load clicks", () => {
-      var node = React.findDOMNode(menuItemsByLabel.Load[0]);
+      var node = React.findDOMNode(packetsToolbar.refs.fileLoad);
       TestUtils.Simulate.click(node);
       expect(actions.loadPacketsFromFile).toHaveBeenCalled();
     });
 
     it("calls props.actions.savePacketsFromFile on Save clicks", () => {
-      var node = React.findDOMNode(menuItemsByLabel.Save[0]);
+      var node = React.findDOMNode(packetsToolbar.refs.fileSave);
       TestUtils.Simulate.click(node);
       expect(actions.savePacketsToFile).toHaveBeenCalled();
     });

--- a/karma-tests/components/packets-toolbar-spec.js
+++ b/karma-tests/components/packets-toolbar-spec.js
@@ -1,6 +1,7 @@
 /* eslint-env jasmine */
 
 define(function (require) {
+
 "use strict";
 
 var React = require("react");

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,7 @@
 /* eslint quotes:0 */
 
 module.exports = function(config) {
+  
   "use strict";
 
   var baseKarmaConfig = {

--- a/lib/inspector-window.js
+++ b/lib/inspector-window.js
@@ -26,6 +26,7 @@ const { Options } = require("firebug.sdk/lib/core/options.js");
 // Constants
 const { InspectorService } = require("./inspector-service.js");
 
+const nsIFilePicker = Ci.nsIFilePicker;
 const windowType = "RDPInspectorConsole";
 const INSPECTOR_XUL_URL = "chrome://rdpinspector/content/inspector-window.xul";
 
@@ -196,6 +197,61 @@ const InspectorWindow = Class(
     this.win = null;
   },
 
+  onLoadFromFile: function() {
+    let fp = Cc["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
+    fp.init(this.win, null, nsIFilePicker.modeOpen);
+    fp.appendFilters(nsIFilePicker.filterAll);
+    fp.filterIndex = 0;
+
+    let rv = fp.show();
+    if (rv !== nsIFilePicker.returnCancel) {
+      let inputStream = Cc["@mozilla.org/network/file-input-stream;1"]
+        .createInstance(Ci.nsIFileInputStream);
+      let cstream = Cc["@mozilla.org/intl/converter-input-stream;1"]
+        .createInstance(Ci.nsIConverterInputStream);
+
+      // Initialize input stream (read, create)
+      let permFlags = parseInt("0666", 8);
+      inputStream.init(fp.file, 0x01 | 0x08, permFlags, 0);
+      cstream.init(inputStream, "UTF-8", 0, 0);
+
+      // Load JSON data
+      let json = "";
+      let data = {};
+      while (cstream.readString(-1, data) != 0) {
+        json += data.value;
+      }
+      inputStream.close();
+
+      this.postCommand("loaded-packet-list-file", json);
+    }
+  },
+
+  onSaveToFile: function(args) {
+    let { data, filename } = args;
+
+    let fp = Cc["@mozilla.org/filepicker;1"].createInstance(nsIFilePicker);
+    fp.init(this.win, null, nsIFilePicker.modeSave);
+    fp.appendFilters(nsIFilePicker.filterAll);
+    fp.filterIndex = 0;
+    fp.defaultString = filename;
+
+    let rv = fp.show();
+    if (rv !== nsIFilePicker.returnCancel) {
+      // Initialize output stream.
+      let outputStream = Cc["@mozilla.org/network/file-output-stream;1"]
+        .createInstance(Ci.nsIFileOutputStream);
+
+      // write, create, truncate
+      let permFlags = parseInt("0666", 8);
+      outputStream.init(fp.file, 0x02 | 0x08 | 0x20, permFlags, 0);
+
+      // Store JSON
+      outputStream.write(data, data.length);
+      outputStream.close();
+    }
+  },
+
   // Transport Listener
 
   onSendPacket: function(packet) {
@@ -245,6 +301,13 @@ const InspectorWindow = Class(
 
     case "pause":
       this.onPause(args);
+      break;
+
+    case "load-from-file":
+      this.onLoadFromFile(args);
+      break;
+    case "save-to-file":
+      this.onSaveToFile(args);
       break;
     }
   },


### PR DESCRIPTION
This pull request (which will fix #22) adds a new File menu in the packets panel toolbar, the related save/load methods in the actions singleton and serialize/deserialize methods in the PacketsStore.
It renders a bootstrap based warning alert (auto dismissed within 2 seconds) on serializing/deserializing errors.

The two commits contain the karma unit tests which ensure the presence of the new packets panel toolbar menu and ensure the load/save actions are called when the user clicks on the corresponding menu items:

- https://travis-ci.org/rpl/rdp-inspector/builds/62935280#L287-L294

Follows a screencast of the feature:

![rdp-inspector-saveload-packets](https://cloud.githubusercontent.com/assets/11484/7671826/1477f558-fcde-11e4-84af-95b1227f6136.gif)
  