### PR TITLE
add key to select options in ActorsToolbar (fix #41)

### DIFF
--- a/data/inspector/components/actors-toolbar.js
+++ b/data/inspector/components/actors-toolbar.js
@@ -27,7 +27,7 @@ var ActorsToolbar = React.createClass({
 
     var options = Object.keys(panelTypesLabels).map((value) => {
       var label = panelTypesLabels[value];
-      return OPTION({ value: value }, label);
+      return OPTION({ value: value, key: value }, label);
     })
 
     return (


### PR DESCRIPTION
This pull request add a key property to the OPTION elements to fix the related react warnings.