### PR TITLE
Packet React component should not render errorMessage if packet.error is null

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,9 @@
     "indent": [0, 2],
     "quotes": [2, "double"],
     "linebreak-style": [1, "unix"],
-    "semi": [1, "always"]
+    "semi": [1, "always"],
+    "new-cap": [1],
+    "eqeqeq": [1]
   },
   "env": {
     "es6": true,
@@ -11,6 +13,10 @@
     "amd": true
   },
   "globals": {
-    "define": true
+    "define": true,
+
+    "Str": true,
+    "Locale": true,
+    "Options": true
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
 - npm --version
 
 before_script:
-- npm install karma-spec-reporter
 - npm install jpm -g
 - npm install mozilla-download -g
 - cd ..

--- a/data/inspector/components/packet.js
+++ b/data/inspector/components/packet.js
@@ -1,19 +1,18 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports /*, module */) {
+
+"use strict";
 
 // ReactJS
 const React = require("react");
-const ReactBootstrap = require("react-bootstrap");
 
 // Firebug SDK
 const { Reps } = require("reps/reps");
 const { TreeView } = require("reps/tree-view");
-const { Obj } = require("reps/object");
 
 // Constants
-const Panel = React.createFactory(ReactBootstrap.Panel);
-const { DIV, SPAN, BR, IMG } = Reps.DOM;
+const { DIV, SPAN } = Reps.DOM;
 
 /**
  * @template This template is responsible for rendering a packet.
@@ -32,7 +31,7 @@ var Packet = React.createClass({
    * 'show inline details' option changes. This is an optimization
    * the makes the packet-list rendering a lot faster.
    */
-  shouldComponentUpdate: function(nextProps, nextState) {
+  shouldComponentUpdate: function(nextProps /*, nextState*/) {
     return (this.props.selected != nextProps.selected ||
       this.props.showInlineDetails != nextProps.showInlineDetails);
   },
@@ -49,7 +48,7 @@ var Packet = React.createClass({
     var timeText = time.toLocaleTimeString() + "." + time.getMilliseconds();
     var previewData = {
       packet: packet
-    }
+    };
 
     // Error packets have its own styling
     if (packet.error) {
@@ -106,10 +105,12 @@ var Packet = React.createClass({
                   SPAN({}, packet.from),
                   SPAN({className: "info"}, timeText + ", " + size)
                 ),
-                DIV({className: "errorMessage"},
+                // NOTE: on issue #44, a long "consoleAPICall" received packet
+          			// was wrongly turned into a "div.errorMessage"
+                packet.error ? DIV({className: "errorMessage"},
                   DIV({}, packet.error),
                   DIV({}, packet.message)
-                ),
+                ) : null,
                 DIV({className: "preview"},
                   preview
                 )

--- a/karma-tests/components/packet-spec.js
+++ b/karma-tests/components/packet-spec.js
@@ -1,0 +1,92 @@
+/* See license.txt for terms of usage */
+/* eslint-env jasmine */
+
+define(function (require) {
+
+"use strict";
+
+var React = require("react");
+var { TestUtils } = React.addons;
+
+var { Packet } = require("components/packet");
+const { TreeViewComponent } = require("reps/tree-view");
+
+var ReactMatchers = require("karma-tests/custom-react-matchers");
+
+describe("Packet", () => {
+  beforeAll(() => {
+    jasmine.addMatchers(ReactMatchers);
+  });
+
+	//TODO: currently skipped, until TreeView component is exported from firebug.sdk
+  xit("contains a TreeView for props.data.packet only if props.showInlineDetails is true", () => {
+    var packet;
+
+		var data = {
+			type: "receive",
+			size: 0,
+			id: 1,
+			time: new Date("2015-06-09T16:48:50.162Z"),
+			packet: {}
+		};
+
+		packet = TestUtils.renderIntoDocument(Packet({
+			showInlineDetails: false,
+			data: data
+		}));
+
+    //TODO: needs TreeView component exported from firebug.sdk
+    expect(TreeViewComponent).toBeFoundInReactTree(packet, 0);
+
+		packet = TestUtils.renderIntoDocument(Packet({
+			showInlineDetails: true,
+			data: data
+		}));
+
+		//TODO: needs TreeView component exported from firebug.sdk
+    expect(TreeViewComponent).toBeFoundInReactTree(packet, 1);
+  });
+
+  describe("issues", () => {
+		it("#44 - Long packet value breaks the view", () => {
+			var data = {
+				type: "receive",
+				size: 0,
+				id: 1,
+				time: new Date("2015-06-09T16:48:50.162Z"),
+				packet: {
+					error: null,
+					message: {
+						"groupName": "",
+						"columnNumber": 13,
+						"lineNumber": 48,
+						"workerType": "none",
+						"level": "table",
+						"counter": null,
+						"arguments": [],
+						"functionName": "onExecuteTest1"
+					},
+					"type": "consoleAPICall",
+					"from": "server1.conn1.child1/consoleActor2"
+				}
+			};
+
+			var packet = TestUtils.renderIntoDocument(Packet({
+				showInlineDetails: false,
+				data: data
+			}));
+
+			var el = React.findDOMNode(packet);
+
+			expect(el).toBeDefined();
+
+			// NOTE: prior the fix, a long "consoleAPICall" received packet
+			// was wrongly turned into a "div.errorMessage"
+			var errorMessage = el.querySelector(".errorMessage");
+			expect(errorMessage).toEqual(null);
+		});
+	})
+
+});
+
+});

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,7 @@
 /* eslint quotes:0 */
 
 module.exports = function(config) {
-  
+
   "use strict";
 
   var baseKarmaConfig = {
@@ -68,10 +68,13 @@ module.exports = function(config) {
     console.log("CODE COVERAGE ENABLED");
     config.set({
       coverageReporter: {
-        type: 'html',
-        dir: 'coverage/',
+        reporters: [
+          { type: "html", subdir: "html/" },
+          { type: "text" },
+          { type: "text-summary" }
+        ],
         instrumenters: {
-          istanbul: require("istanbul-harmony")
+          istanbul: require("isparta")
         }
       },
       preprocessors: {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   "scripts": {
     "test": "npm run karma-tests && npm run jpm-tests",
     "karma-tests": "karma start --single-run --reporters spec",
-    "travis-ci": "npm run karma-tests && npm run jpm-tests -- -v",
+    "karma-coverage": "CODE_COVERAGE=true npm run karma-tests -- --reporters spec,coverage",
     "watch-karma-tests": "karma start --no-single-run --reporters spec --auto-watch",
-    "watch-karma-coverage": "COVERAGE=true npm run watch-karma-tests",
-    "jpm-tests": "jpm test"
+    "watch-karma-coverage": "CODE_COVERAGE=true npm run watch-karma-tests",
+    "jpm-tests": "jpm test",
+    "travis-ci": "npm run jpm-tests -- -v && npm run karma-coverage"
   },
   "engines": {
     "firefox": ">=38.0 <=40.0"
@@ -72,7 +73,7 @@
   },
   "devDependencies": {
     "eslint": "^0.21.0",
-    "istanbul-harmony": "git://github.com/fengmk2/istanbul#harmony-0.3.x",
+    "isparta": "^3.0.3",
     "jasmine-core": "^2.3.2",
     "karma": "^0.12.31",
     "karma-cli": "0.0.4",


### PR DESCRIPTION
This pull request introduces:

- a small fix for #44 and related spec test (Packet React component should not render errorMessage if packet.error):
  - https://github.com/firebug/rdp-inspector/compare/master...rpl:fix/44?expand=1#diff-7fc17a2eae531632ff955af7c212f748R108
  - https://github.com/firebug/rdp-inspector/compare/master...rpl:fix/44?expand=1#diff-d204de2a6152530740205f7cdb2f02bfR51
  - https://travis-ci.org/rpl/rdp-inspector#L546
- fix npm install issues related to es6 code coverage (change deprecated istanbul-harmony with isparta)
- enhance travis-ci build log with code coverage stats:
  - https://travis-ci.org/rpl/rdp-inspector#L561