### PR TITLE
Fix lint errors and run eslint during travis-ci builds

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,9 @@
     "indent": [0, 2],
     "quotes": [2, "double"],
     "linebreak-style": [1, "unix"],
-    "semi": [1, "always"]
+    "semi": [1, "always"],
+    "new-cap": [1],
+    "eqeqeq": [1]
   },
   "env": {
     "es6": true,
@@ -11,6 +13,10 @@
     "amd": true
   },
   "globals": {
-    "define": true
+    "define": true,
+
+    "Str": true,
+    "Locale": true,
+    "Options": true
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,8 @@
     "indent": [0, 2],
     "linebreak-style": [0],
     "eqeqeq": [0],
-    "new-cap": [0]
+    "new-cap": [0],
+    "no-new": [0]
   },
   "env": {
     "es6": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "rules": {
+    "no-mixed-spaces-and-tabs": [2],
     "quotes": [2, "double"],
     "semi": [1, "always"],
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,12 @@
 {
   "rules": {
-    "indent": [0, 2],
     "quotes": [2, "double"],
-    "linebreak-style": [1, "unix"],
     "semi": [1, "always"],
-    "new-cap": [1],
-    "eqeqeq": [1]
+
+    "indent": [0, 2],
+    "linebreak-style": [0],
+    "eqeqeq": [0],
+    "new-cap": [0]
   },
   "env": {
     "es6": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,8 @@
   },
   "globals": {
     "define": true,
+    "require": true,
+    "requirejs": true,
 
     "Str": true,
     "Locale": true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
 - npm --version
 
 before_script:
-- npm install karma-spec-reporter
 - npm install jpm -g
 - npm install mozilla-download -g
 - cd ..

--- a/data/inspector/actors-store.js
+++ b/data/inspector/actors-store.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 /**
  * This object contains all collected actors. It's also responsible
@@ -42,12 +44,12 @@ ActorsStore.prototype =
     if (data instanceof Array) {
       data.forEach((item) => {
         this.collectActorIDs(item, res);
-      })
+      });
     } else if (data instanceof Object) {
       if (data.pool) {
         this.collectActorIDs(data.pool, res);
       } else if (data.actorID) {
-        var { actorID } = data
+        var { actorID } = data;
         if (res.indexOf(actorID) < 0) {
           res.push(actorID);
         }
@@ -61,9 +63,9 @@ ActorsStore.prototype =
     this.app.setState({
       actors: this.actors,
       actorIDs: this.actorIDs
-    })
+    });
   }
-}
+};
 
 // Exports from this module
 exports.ActorsStore = ActorsStore;

--- a/data/inspector/components/actors-panel.js
+++ b/data/inspector/components/actors-panel.js
@@ -1,10 +1,11 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // Dependencies
 const React = require("react");
-const ReactBootstrap = require("react-bootstrap");
 
 // Firebug SDK
 
@@ -14,9 +15,7 @@ const { Reps } = require("reps/repository");
 const { ActorsToolbar } = require("./actors-toolbar");
 
 // Shortcuts
-const { TR, TD, SPAN, TABLE, TBODY, THEAD, TH, DIV, H4 } = Reps.DOM;
-const TabbedArea = React.createFactory(ReactBootstrap.TabbedArea);
-const TabPane = React.createFactory(ReactBootstrap.TabPane);
+const { TR, TD, TABLE, TBODY, THEAD, TH, DIV, H4 } = Reps.DOM;
 
 const GLOBAL_ACTORS_POOLS = "global-actors-pool";
 const TAB_ACTORS_POOLS = "tab-actors-pool";
@@ -38,7 +37,7 @@ var ActorsPanel = React.createClass({
   getInitialState: function() {
     return {
       panelType: GLOBAL_ACTORS_POOLS
-    }
+    };
   },
 
   render: function() {
@@ -51,20 +50,20 @@ var ActorsPanel = React.createClass({
     case GLOBAL_ACTORS_POOLS:
       el = ActorsPools({
         data: (actors && actors.global),
-        key: 'global',
+        key: "global",
         searchFilter: this.props.searchFilter
       });
       break;
     case TAB_ACTORS_POOLS:
       el = ActorsPools({
         data: (actors && actors.tab),
-        key: 'tab',
+        key: "tab",
         searchFilter: this.props.searchFilter
       });
       break;
     case ACTORS_FACTORIES:
       el = ActorsFactories({
-        key: 'factories',
+        key: "factories",
         data: {
           global: actors && actors.global,
           tab: actors && actors.tab
@@ -79,7 +78,7 @@ var ActorsPanel = React.createClass({
         ActorsToolbar({ actions: this.props.actions,
           currentPanelType: panelType,
           panelTypesLabels: PanelTypesLabels,
-          onPanelTypeSelected: this.onPanelTypeSelected,
+          onPanelTypeSelected: this.onPanelTypeSelected
         }),
         DIV({ className: "actorsScrollBox" }, el)
       )
@@ -89,7 +88,7 @@ var ActorsPanel = React.createClass({
   onPanelTypeSelected: function(panelType) {
     this.setState({
       panelType: panelType
-    })
+    });
   }
 });
 
@@ -102,14 +101,14 @@ var ActorsPools = React.createFactory(React.createClass({
   displayName: "ActorsPools",
 
   render: function() {
-    var pool = [];
+    var pools = [];
 
     if (this.props.data) {
       var { actorPool, extraPools } = this.props.data;
-      pool = pool.concat(actorPool, extraPools);
+      pools = pools.concat(actorPool, extraPools);
     }
 
-    var poolTables = pool.map((poolData) => {
+    var poolTables = pools.map((poolData) => {
       var pool = poolData.pool;
       var poolId = poolData.id;
       var actorClass = false;
@@ -156,7 +155,7 @@ var PoolTable = React.createFactory(React.createClass({
       }
       actors[i].key = actors[i].actorID;
       rows.push(PoolRow(actors[i]));
-    };
+    }
 
     // Pools are mixed with Actor objects (created using CreateClass).
     var className = "poolTable";
@@ -207,6 +206,42 @@ var PoolRow = React.createFactory(React.createClass({
 }));
 
 /**
+ * @template This template renders a single 'FactoryTable' component.
+ */
+var FactoryTable = React.createFactory(React.createClass({
+  /** @lends FactoryTable */
+
+  displayName: "FactoryTable",
+
+  render: function() {
+    var rows = [];
+
+    var factories = this.props.factories;
+    for (var i in factories) {
+      if (this.props.searchFilter &&
+          JSON.stringify(factories[i]).indexOf(this.props.searchFilter) < 0) {
+        // filter out packets which don't match the filter
+        continue;
+      }
+
+      factories[i].key = factories[i].prefix + factories[i].name;
+      rows.push(FactoryRow(factories[i]));
+    }
+
+    return (
+      TABLE({className: "poolTable"},
+        THEAD({className: "poolRow"},
+          TH({width: "33%"}, "Name"),
+          TH({width: "33%"}, "Prefix"),
+          TH({width: "33%"}, "Constructor")
+        ),
+        TBODY(null, rows)
+      )
+    );
+  }
+}));
+
+/**
  * @template This template renders the 'ActorsFactories' list of tables.
  */
 var ActorsFactories = React.createFactory(React.createClass({
@@ -229,42 +264,6 @@ var ActorsFactories = React.createFactory(React.createClass({
         FactoryTable({ factories: child.factories.global, searchFilter: searchFilter }),
         H4(null, "Child Process - Tab Factories"),
         FactoryTable({ factories: child.factories.tab, searchFilter: searchFilter })
-      )
-    );
-  }
-}));
-
-/**
- * @template This template renders a single 'FactoryTable' component.
- */
-var FactoryTable = React.createFactory(React.createClass({
-  /** @lends FactoryTable */
-
-  displayName: "FactoryTable",
-
-  render: function() {
-    var rows = [];
-
-    var factories = this.props.factories;
-    for (var i in factories) {
-      if (this.props.searchFilter &&
-          JSON.stringify(factories[i]).indexOf(this.props.searchFilter) < 0) {
-        // filter out packets which don't match the filter
-        continue;
-      }
-
-      factories[i].key = factories[i].prefix + factories[i].name;
-      rows.push(FactoryRow(factories[i]));
-    };
-
-    return (
-      TABLE({className: "poolTable"},
-        THEAD({className: "poolRow"},
-          TH({width: "33%"}, "Name"),
-          TH({width: "33%"}, "Prefix"),
-          TH({width: "33%"}, "Constructor")
-        ),
-        TBODY(null, rows)
       )
     );
   }

--- a/data/inspector/components/actors-toolbar.js
+++ b/data/inspector/components/actors-toolbar.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // Dependencies
 var React = require("react");
@@ -11,7 +13,7 @@ var ButtonToolbar = React.createFactory(ReactBootstrap.ButtonToolbar);
 var Button = React.createFactory(ReactBootstrap.Button);
 
 const { Reps } = require("reps/reps");
-const { DIV, SELECT, OPTION } = Reps.DOM;
+const { SELECT, OPTION } = Reps.DOM;
 
 /**
  * @template This object is responsible for rendering the toolbar
@@ -28,7 +30,7 @@ var ActorsToolbar = React.createClass({
     var options = Object.keys(panelTypesLabels).map((value) => {
       var label = panelTypesLabels[value];
       return OPTION({ value: value, key: value }, label);
-    })
+    });
 
     return (
       ButtonToolbar({className: "toolbar"},
@@ -39,12 +41,12 @@ var ActorsToolbar = React.createClass({
           options
         )
       )
-    )
+    );
   },
 
   // Commands
 
-  onRefresh: function(event) {
+  onRefresh: function(/*event*/) {
     this.props.actions.getActors();
   },
 

--- a/data/inspector/components/factories.js
+++ b/data/inspector/components/factories.js
@@ -1,12 +1,14 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // Dependencies
 const { Reps } = require("reps/reps");
 
 var React = require("react");
-const { TR, TD, SPAN, TABLE, TBODY, THEAD, TH, DIV, H4 } = Reps.DOM;
+const { TR, TD, TABLE, TBODY, THEAD, TH, DIV, H4 } = Reps.DOM;
 
 // Templates
 
@@ -52,7 +54,7 @@ var FactoryTable = React.createFactory(React.createClass({
 
       factories[i].key = factories[i].prefix + factories[i].name;
       rows.push(FactoryRow(factories[i]));
-    };
+    }
 
     return (
       TABLE({className: "poolTable"},
@@ -83,7 +85,6 @@ var FactoryList = React.createFactory(React.createClass({
     };
   },
   render: function() {
-    var mainGlobal = [];
     var main = this.state.main;
     var child = this.state.child;
     var searchFilter = this.state.searchFilter;
@@ -108,7 +109,7 @@ var Factories = {
   render: function(parentNode) {
     return React.render(FactoryList(), parentNode);
   }
-}
+};
 
 // Exports from this module
 exports.Factories = Factories;

--- a/data/inspector/components/main-tabbed-area.js
+++ b/data/inspector/components/main-tabbed-area.js
@@ -1,13 +1,12 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // ReactJS
 var React = require("react");
 var ReactBootstrap = require("react-bootstrap");
-
-// Firebug SDK
-const { Reps } = require("reps/reps");
 
 // RDP Inspector
 const { ActorsPanel } = require("./actors-panel");
@@ -18,7 +17,6 @@ const { SearchBox } = require("./search-box");
 const TabbedArea = React.createFactory(ReactBootstrap.TabbedArea);
 const TabPane = React.createFactory(ReactBootstrap.TabPane);
 const Alert = React.createFactory(ReactBootstrap.Alert);
-const { DIV } = Reps.DOM;
 
 /**
  * @template This template is responsible for rendering the main
@@ -48,7 +46,7 @@ var MainTabbedArea = React.createClass({
   onErrorDismiss: function() {
     this.setState({
       error: null
-    })
+    });
   },
 
   render: function() {

--- a/data/inspector/components/packet-details.js
+++ b/data/inspector/components/packet-details.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // Dependencies
 const React = require("react");

--- a/data/inspector/components/packet-editor.js
+++ b/data/inspector/components/packet-editor.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // Dependencies
 const React = require("react");
@@ -29,7 +31,7 @@ var PacketEditorToolbar = React.createFactory(React.createClass({
     return ButtonToolbar({className: "toolbar"}, [
       Button({ onClick: this.props.onSend, key: "send",
                bsStyle: "primary", bsSize: "xsmall",
-               style: { marginLeft: 12, color: 'white' } }, "Send"),
+               style: { marginLeft: 12, color: "white" } }, "Send"),
 
       Button({ onClick: this.props.onRedo, key: "redo",
                className: "pull-right",
@@ -44,7 +46,7 @@ var PacketEditorToolbar = React.createFactory(React.createClass({
       Button({ onClick: this.props.onClear, key: "clear",
                className: "pull-right",
                bsStyle: "danger", bsSize: "xsmall",
-               style: { marginRight: 6, color: 'white' } }, "Clear")
+               style: { marginRight: 6, color: "white" } }, "Clear")
     ]);
   }
 }));
@@ -67,7 +69,7 @@ var PacketEditor = React.createClass({
 
   componentWillReceiveProps: function(nextProps) {
     this.setState({
-      selectedPacket: this.props.selectedPacket
+      selectedPacket: nextProps.selectedPacket
     });
   },
 
@@ -100,19 +102,19 @@ var PacketEditor = React.createClass({
 
                 // remove starting and ending '"' if any
                 parsedValue = typeof value == "string" ?
-                  value.replace(/^"|"$/g, '') : "";
+                  value.replace(/^"|"$/g, "") : "";
 
                 if(keyPath.length == 1 && keyPath[0] == "to") {
                   // get a suggestion list by filtering actorIDs list
                   return actorIDs.filter((suggestion) => {
-                    return suggestion.indexOf(parsedValue) >= 0
-                  })
+                    return suggestion.indexOf(parsedValue) >= 0;
+                  });
                 }
               } catch(e) {
-
+                //console.debug("exception on parsing autocompletion", e);
               }
 
-              return []
+              return [];
             }
           })
          )

--- a/data/inspector/components/packet-list.js
+++ b/data/inspector/components/packet-list.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // Dependencies
 const React = require("react");
@@ -71,7 +73,7 @@ var PacketList = React.createClass({
       if (packet.type == "message") {
         output.push(PacketsMessage({
           key: packet.id,
-          data: packet,
+          data: packet
         }));
         continue;
       }
@@ -90,7 +92,7 @@ var PacketList = React.createClass({
         selected: selected,
         showInlineDetails: this.props.showInlineDetails
       }));
-    };
+    }
 
     return (
       DIV({className: "list"},

--- a/data/inspector/components/packet.js
+++ b/data/inspector/components/packet.js
@@ -106,7 +106,7 @@ var Packet = React.createClass({
                   SPAN({className: "info"}, timeText + ", " + size)
                 ),
                 // NOTE: on issue #44, a long "consoleAPICall" received packet
-          			// was wrongly turned into a "div.errorMessage"
+                // was wrongly turned into a "div.errorMessage"
                 packet.error ? DIV({className: "errorMessage"},
                   DIV({}, packet.error),
                   DIV({}, packet.message)

--- a/data/inspector/components/packet.js
+++ b/data/inspector/components/packet.js
@@ -1,19 +1,18 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports /*, module */) {
+
+"use strict";
 
 // ReactJS
 const React = require("react");
-const ReactBootstrap = require("react-bootstrap");
 
 // Firebug SDK
 const { Reps } = require("reps/reps");
 const { TreeView } = require("reps/tree-view");
-const { Obj } = require("reps/object");
 
 // Constants
-const Panel = React.createFactory(ReactBootstrap.Panel);
-const { DIV, SPAN, BR, IMG } = Reps.DOM;
+const { DIV, SPAN } = Reps.DOM;
 
 /**
  * @template This template is responsible for rendering a packet.
@@ -32,7 +31,7 @@ var Packet = React.createClass({
    * 'show inline details' option changes. This is an optimization
    * the makes the packet-list rendering a lot faster.
    */
-  shouldComponentUpdate: function(nextProps, nextState) {
+  shouldComponentUpdate: function(nextProps /*, nextState*/) {
     return (this.props.selected != nextProps.selected ||
       this.props.showInlineDetails != nextProps.showInlineDetails);
   },
@@ -49,7 +48,7 @@ var Packet = React.createClass({
     var timeText = time.toLocaleTimeString() + "." + time.getMilliseconds();
     var previewData = {
       packet: packet
-    }
+    };
 
     // Error packets have its own styling
     if (packet.error) {
@@ -106,10 +105,12 @@ var Packet = React.createClass({
                   SPAN({}, packet.from),
                   SPAN({className: "info"}, timeText + ", " + size)
                 ),
-                DIV({className: "errorMessage"},
+                // NOTE: on issue #44, a long "consoleAPICall" received packet
+          			// was wrongly turned into a "div.errorMessage"
+                packet.error ? DIV({className: "errorMessage"},
                   DIV({}, packet.error),
                   DIV({}, packet.message)
-                ),
+                ) : null,
                 DIV({className: "preview"},
                   preview
                 )

--- a/data/inspector/components/packets-limit.js
+++ b/data/inspector/components/packets-limit.js
@@ -1,10 +1,11 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // ReactJS
 const React = require("react");
-const ReactBootstrap = require("react-bootstrap");
 
 // Firebug SDK
 const { Reps } = require("reps/reps");
@@ -32,7 +33,7 @@ var PacketsLimit = React.createClass({
       DIV({className: "packetsLimit"},
         SPAN({className: "text"}, removedPackets + " " + label)
       )
-    )
+    );
   }
 });
 

--- a/data/inspector/components/packets-message.js
+++ b/data/inspector/components/packets-message.js
@@ -1,10 +1,11 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // ReactJS
 const React = require("react");
-const ReactBootstrap = require("react-bootstrap");
 
 // Firebug SDK
 const { Reps } = require("reps/reps");
@@ -34,7 +35,7 @@ var PacketsMessage = React.createClass({
         DIV({className: "text"}, message),
         DIV({className: "time"}, timeText)
       )
-    )
+    );
   }
 });
 

--- a/data/inspector/components/packets-panel.js
+++ b/data/inspector/components/packets-panel.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // Dependencies
 const React = require("react");
@@ -15,7 +17,7 @@ const { PacketsToolbar } = require("./packets-toolbar");
 const { Splitter } = require("./splitter");
 
 // Shortcuts
-const { TR, TD, TABLE, TBODY, THEAD, TH, DIV } = Reps.DOM;
+const { DIV } = Reps.DOM;
 
 /**
  * @template This template renders 'Packets' tab body.
@@ -68,7 +70,7 @@ var PacketsPanel = React.createClass({
           innerBox: DIV({className: "innerBox"})
         })
       )
-    )
+    );
   }
 });
 

--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -1,20 +1,18 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // ReactJS
 const React = require("react");
 const ReactBootstrap = require("react-bootstrap");
-
-// Firebug SDK
-const { Reps } = require("reps/reps");
 
 // RDP Inspector
 const { PacketDetails } = require("./packet-details");
 const { PacketEditor } = require("./packet-editor");
 
 // Constants
-const { DIV } = Reps.DOM;
 const TabbedArea = React.createFactory(ReactBootstrap.TabbedArea);
 const TabPane = React.createFactory(ReactBootstrap.TabPane);
 
@@ -30,16 +28,16 @@ var PacketsSidebar = React.createClass({
   getInitialState: function() {
     return {
       activeKey: 1
-    }
+    };
   },
 
   onTabSelected: function(key) {
     this.setState({
       activeKey: key
-    })
+    });
   },
 
-  componentWillReceiveProps: function(nextProps) {
+  componentWillReceiveProps: function(/*nextProps*/) {
     // TODO: it would be nice reset activeKey to the "Packet" Detail sidebar
     // but only when the parent component pass a new selectedPacket
   },

--- a/data/inspector/components/packets-summary.js
+++ b/data/inspector/components/packets-summary.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // ReactJS
 const React = require("react");
@@ -8,13 +10,26 @@ const ReactBootstrap = require("react-bootstrap");
 
 // Firebug SDK
 const { Reps } = require("reps/reps");
-const { TreeView } = require("reps/tree-view");
-const { Obj } = require("reps/object");
 
 // Constants
 const Tooltip = React.createFactory(ReactBootstrap.Tooltip);
 const OverlayTrigger = React.createFactory(ReactBootstrap.OverlayTrigger);
 const { DIV } = Reps.DOM;
+
+/**
+ * @template Helper template responsible for rendering a tooltip.
+ */
+const TextWithTooltip = React.createFactory(React.createClass({
+  render: function() {
+    var tooltip = Tooltip({}, this.props.tooltip);
+    return (
+      OverlayTrigger({placement: "top", overlay: tooltip, delayShow: 200,
+        delayHide: 150},
+        DIV({}, this.props.children)
+      )
+    );
+  }
+}));
 
 /**
  * @template This template is responsible for rendering packet summary
@@ -60,24 +75,9 @@ var PacketsSummary = React.createClass({
         DIV({className: "separator"}),
         DIV({className: "time"}, timeText)
       )
-    )
-  }
-});
-
-/**
- * @template Helper template responsible for rendering a tooltip.
- */
-const TextWithTooltip = React.createFactory(React.createClass({
-  render: function() {
-    var tooltip = Tooltip({}, this.props.tooltip);
-    return (
-      OverlayTrigger({placement: "top", overlay: tooltip, delayShow: 200,
-        delayHide: 150},
-        DIV({}, this.props.children)
-      )
     );
   }
-}));
+});
 
 // Exports from this module
 exports.PacketsSummary = React.createFactory(PacketsSummary);

--- a/data/inspector/components/packets-toolbar.js
+++ b/data/inspector/components/packets-toolbar.js
@@ -1,7 +1,7 @@
 /* See license.txt for terms of usage */
 /* globals Locale */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
 
 "use strict";
 
@@ -77,20 +77,20 @@ var PacketsToolbar = React.createClass({
           SPAN({className: "glyphicon glyphicon-pause", "aria-hidden": true})
         )
       )
-    )
+    );
   },
 
   // Commands
 
-  onClear: function(event) {
+  onClear: function(/*event*/) {
     this.props.actions.clear();
   },
 
-  onFind: function(event) {
+  onFind: function(/*event*/) {
     this.props.actions.find();
   },
 
-  onSummary: function(event) {
+  onSummary: function(/*event*/) {
     this.props.actions.appendSummary();
   },
 
@@ -104,17 +104,17 @@ var PacketsToolbar = React.createClass({
     this.refs.options.setDropdownState(false);
   },
 
-  onPause: function(event) {
+  onPause: function(/*event*/) {
     this.props.actions.onPause();
   },
 
-  onLoadPacketsFromFile: function(event) {
+  onLoadPacketsFromFile: function(/*event*/) {
     this.props.actions.loadPacketsFromFile();
     this.refs.fileMenu.setDropdownState(false);
 
   },
 
-  onSavePacketsFromFile: function(event) {
+  onSavePacketsFromFile: function(/*event*/) {
     this.props.actions.savePacketsToFile();
     this.refs.fileMenu.setDropdownState(false);
   }

--- a/data/inspector/components/pools.js
+++ b/data/inspector/components/pools.js
@@ -1,11 +1,13 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // Dependencies
 const { Reps } = require("reps/reps");
 const React = require("react");
-const { TR, TD, SPAN, TABLE, TBODY, THEAD, TH, DIV, H4 } = Reps.DOM;
+const { TR, TD, TABLE, TBODY, THEAD, TH, DIV, H4 } = Reps.DOM;
 
 // Templates
 
@@ -53,7 +55,7 @@ var PoolTable = React.createFactory(React.createClass({
       }
       actors[i].key = actors[i].actorID;
       rows.push(PoolRow(actors[i]));
-    };
+    }
 
     // Pools are mixed with Actor objects (created using CreateClass).
     var className = "poolTable";
@@ -119,7 +121,7 @@ var PoolList = React.createFactory(React.createClass({
         key: i,
         searchFilter: this.state.searchFilter
       }));
-    };
+    }
 
     return (
       DIV({className: "poolContainer"},
@@ -133,7 +135,7 @@ var Pools = {
   render: function(parentNode) {
     return React.render(PoolList(), parentNode);
   }
-}
+};
 
 // Exports from this module
 exports.Pools = Pools;

--- a/data/inspector/components/search-box.js
+++ b/data/inspector/components/search-box.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 /**
  * TODO docs xxxHonza: can we use ReactJS?
@@ -32,22 +34,22 @@ var SearchBox =
     searchBox.remove();
   },
 
-  onKeyPress: function(searchBox, event) {
+  onKeyPress: function(searchBox/*, event*/) {
     this.onSearch(searchBox);
   },
 
-  onChange: function(searchBox, event) {
+  onChange: function(searchBox/*, event*/) {
     this.onSearch(searchBox);
   },
 
   onSearch: function(searchBox) {
     var win = searchBox.ownerDocument.defaultView;
     var event = new win.MessageEvent("search", {
-      data: searchBox.value,
+      data: searchBox.value
     });
     win.dispatchEvent(event);
   }
-}
+};
 
 // Exports from this module
 exports.SearchBox = SearchBox;

--- a/data/inspector/components/splitter.js
+++ b/data/inspector/components/splitter.js
@@ -1,10 +1,11 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 // ReactJS
 const React = require("react");
-const ReactBootstrap = require("react-bootstrap");
 
 // RDP Inspector
 const { Tracker } = require("../tracker");
@@ -43,7 +44,7 @@ var Splitter = React.createClass({
 
   // Resizing
 
-  onDragStart: function(tracker) {
+  onDragStart: function(/*tracker*/) {
     var splitter = this.refs.splitter.getDOMNode();
     var body = splitter.ownerDocument.body;
     body.setAttribute("resizing", "true");
@@ -52,7 +53,7 @@ var Splitter = React.createClass({
     this.rightWidth = rightPanel.clientWidth;
   },
 
-  onDragOver: function(newPos, tracker) {
+  onDragOver: function(newPos/*, tracker*/) {
     var rightPanel = this.refs.rightPanel.getDOMNode();
     var newWidth = (this.rightWidth - newPos.x);
     if (newWidth < this.props.min) {
@@ -62,7 +63,7 @@ var Splitter = React.createClass({
     rightPanel.style.width = newWidth + "px";
   },
 
-  onDrop: function(tracker) {
+  onDrop: function(/*tracker*/) {
     var splitter = this.refs.splitter.getDOMNode();
     var body = splitter.ownerDocument.body;
     body.removeAttribute("resizing");
@@ -87,8 +88,8 @@ var Splitter = React.createClass({
           rightPanel
         )
       )
-    )
-  },
+    );
+  }
 });
 
 // Exports from this module

--- a/data/inspector/config.js
+++ b/data/inspector/config.js
@@ -9,7 +9,7 @@ require.config({
     "bootstrap": "../lib/bootstrap/js/bootstrap",
     "immutable": "../lib/immutable/immutable",
     "react-bootstrap": "../lib/react-bootstrap/react-bootstrap",
-    "reps": "../../node_modules/firebug.sdk/lib/reps",
+    "reps": "../../node_modules/firebug.sdk/lib/reps"
   }
 });
 

--- a/data/inspector/frame-script.js
+++ b/data/inspector/frame-script.js
@@ -1,19 +1,22 @@
 /* See license.txt for terms of usage */
 
+(function({
+  Components,
+  content,
+  addEventListener,
+  sendAsyncMessage,
+  addMessageListener,
+  /*removeMessageListener*/
+}) {
+
 "use strict";
 
-(function({
-  content,
-  addMessageListener,
-  sendAsyncMessage,
-  removeMessageListener,
-  addEventListener}) {
 
 const Cu = Components.utils;
-const Cc = Components.classes;
-const Ci = Components.interfaces;
+/*const Cc = Components.classes;
+const Ci = Components.interfaces;*/
 
-const document = content.document;
+/*const document = content.document;*/
 const window = content;
 
 /**
@@ -29,11 +32,11 @@ function messageListener(message) {
     data: data,
     origin: origin,
     target: window,
-    source: window,
+    source: window
   });
 
   window.dispatchEvent(event);
-};
+}
 
 addMessageListener("rdpinspector/event/message", messageListener);
 
@@ -43,7 +46,7 @@ addMessageListener("rdpinspector/event/message", messageListener);
 function postChromeMessage(type, args, objects) {
   let data = {
     type: type,
-    args: args,
+    args: args
   };
 
   sendAsyncMessage("message", data, objects);
@@ -54,7 +57,7 @@ function postChromeMessage(type, args, objects) {
  * as it's loaded. This function allows sending messages from the
  * frame's content directly to the chrome scope.
  */
-addEventListener("DOMContentLoaded", function onContentLoaded(event) {
+addEventListener("DOMContentLoaded", function onContentLoaded(/*event*/) {
   removeEventListener("DOMContentLoaded", onContentLoaded, true);
 
   Cu.exportFunction(postChromeMessage, window, {

--- a/data/inspector/main.js
+++ b/data/inspector/main.js
@@ -1,7 +1,7 @@
 /* See license.txt for terms of usage */
-/* globals Locale, postChromeMessage */
+/* globals postChromeMessage */
 
-define(function(require, exports, module) {
+define(function(require/*, exports, module*/) {
 
 "use strict";
 
@@ -14,6 +14,9 @@ var { PacketsStore } = require("packets-store");
 var { ActorsStore } = require("actors-store");
 var { Resizer } = require("resizer");
 var { Search } = require("search");
+
+var packetsStore;
+var theApp;
 
 /**
  * List of all application commands. The list is passed into
@@ -130,12 +133,12 @@ var actions = {
  * at the top of the window. This component also represents ReactJS root.
  */
 var content = document.getElementById("content");
-var theApp = React.render(MainTabbedArea({
+theApp = React.render(MainTabbedArea({
   actions: actions
 }), content);
 
 // Helper modules for handling application events.
-var packetsStore = new PacketsStore(window, theApp);
+packetsStore = new PacketsStore(window, theApp);
 var actorsStore = new ActorsStore(window, theApp);
 var resizer = new Resizer(window, theApp);
 var search = new Search(window, theApp);

--- a/data/inspector/main.js
+++ b/data/inspector/main.js
@@ -139,9 +139,9 @@ theApp = React.render(MainTabbedArea({
 
 // Helper modules for handling application events.
 packetsStore = new PacketsStore(window, theApp);
-var actorsStore = new ActorsStore(window, theApp);
-var resizer = new Resizer(window, theApp);
-var search = new Search(window, theApp);
+new ActorsStore(window, theApp);
+new Resizer(window, theApp);
+new Search(window, theApp);
 
 // Send notification about initialization being done.
 postChromeMessage("initialized");

--- a/data/inspector/packets-store.js
+++ b/data/inspector/packets-store.js
@@ -1,7 +1,7 @@
 /* See license.txt for terms of usage */
 /* globals Options */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
 
 "use strict";
 

--- a/data/inspector/resizer.js
+++ b/data/inspector/resizer.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 /**
  * This object is responsible for setting proper body height
@@ -22,8 +24,8 @@ Resizer.prototype =
     var doc = this.win.document;
     doc.body.style.height = this.win.innerHeight + "px";
     doc.body.style.width = this.win.innerWidth + "px";
-  },
-}
+  }
+};
 
 // Exports from this module
 exports.Resizer = Resizer;

--- a/data/inspector/search.js
+++ b/data/inspector/search.js
@@ -1,6 +1,8 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
 
 /**
  * This object is responsible for listening search events
@@ -19,8 +21,8 @@ Search.prototype =
   onSearch: function(event) {
     var value = event.data;
     this.app.setState({searchFilter: value});
-  },
-}
+  }
+};
 
 // Exports from this module
 exports.Search = Search;

--- a/data/inspector/tracker.js
+++ b/data/inspector/tracker.js
@@ -1,6 +1,27 @@
 /* See license.txt for terms of usage */
 
-define(function(require, exports, module) {
+define(function(require, exports/*, module*/) {
+
+"use strict";
+
+function absoluteCursorPosition(e) {
+  if (isNaN(window.scrollX)) {
+    return new Position(e.clientX +
+      document.documentElement.scrollLeft +
+      document.body.scrollLeft, e.clientY +
+      document.documentElement.scrollTop +
+      document.body.scrollTop);
+  }
+  else {
+    return new Position(e.clientX + window.scrollX,
+      e.clientY + window.scrollY);
+  }
+}
+
+function cancelEvent(event) {
+  event.stopPropagation();
+  event.preventDefault();
+}
 
 /**
  * Helper object for drag-and-drop. It's used e.g. by the {@Splitter}
@@ -180,7 +201,7 @@ function Position(x, y)
   };
 
   this.Apply = function(element) {
-    if (typeof(element) == "string") {
+    if (typeof element == "string") {
       element = document.getElementById(element);
     }
 
@@ -196,25 +217,6 @@ function Position(x, y)
       element.style.top = this.y + "px";
     }
   };
-}
-
-function absoluteCursorPosition(e) {
-  if (isNaN(window.scrollX)) {
-    return new Position(e.clientX +
-      document.documentElement.scrollLeft +
-      document.body.scrollLeft, e.clientY +
-      document.documentElement.scrollTop +
-      document.body.scrollTop);
-  }
-  else {
-    return new Position(e.clientX + window.scrollX,
-      e.clientY + window.scrollY);
-  }
-}
-
-function cancelEvent(event) {
-  event.stopPropagation();
-  event.preventDefault();
 }
 
 // Exports from this module

--- a/karma-tests/components/main-tabbed-area-spec.js
+++ b/karma-tests/components/main-tabbed-area-spec.js
@@ -6,7 +6,7 @@ define(function (require) {
 "use strict";
 
 var React = require("react");
-var { TestUtils } = React.addons;
+/*var { TestUtils } = React.addons;*/
 
 // Fake actions singleton
 var actions = {};

--- a/karma-tests/components/packet-spec.js
+++ b/karma-tests/components/packet-spec.js
@@ -1,0 +1,92 @@
+/* See license.txt for terms of usage */
+/* eslint-env jasmine */
+
+define(function (require) {
+
+"use strict";
+
+var React = require("react");
+var { TestUtils } = React.addons;
+
+var { Packet } = require("components/packet");
+const { TreeViewComponent } = require("reps/tree-view");
+
+var ReactMatchers = require("karma-tests/custom-react-matchers");
+
+describe("Packet", () => {
+  beforeAll(() => {
+    jasmine.addMatchers(ReactMatchers);
+  });
+
+	//TODO: currently skipped, until TreeView component is exported from firebug.sdk
+  xit("contains a TreeView for props.data.packet only if props.showInlineDetails is true", () => {
+    var packet;
+
+		var data = {
+			type: "receive",
+			size: 0,
+			id: 1,
+			time: new Date("2015-06-09T16:48:50.162Z"),
+			packet: {}
+		};
+
+		packet = TestUtils.renderIntoDocument(Packet({
+			showInlineDetails: false,
+			data: data
+		}));
+
+    //TODO: needs TreeView component exported from firebug.sdk
+    expect(TreeViewComponent).toBeFoundInReactTree(packet, 0);
+
+		packet = TestUtils.renderIntoDocument(Packet({
+			showInlineDetails: true,
+			data: data
+		}));
+
+		//TODO: needs TreeView component exported from firebug.sdk
+    expect(TreeViewComponent).toBeFoundInReactTree(packet, 1);
+  });
+
+  describe("issues", () => {
+		it("#44 - Long packet value breaks the view", () => {
+			var data = {
+				type: "receive",
+				size: 0,
+				id: 1,
+				time: new Date("2015-06-09T16:48:50.162Z"),
+				packet: {
+					error: null,
+					message: {
+						"groupName": "",
+						"columnNumber": 13,
+						"lineNumber": 48,
+						"workerType": "none",
+						"level": "table",
+						"counter": null,
+						"arguments": [],
+						"functionName": "onExecuteTest1"
+					},
+					"type": "consoleAPICall",
+					"from": "server1.conn1.child1/consoleActor2"
+				}
+			};
+
+			var packet = TestUtils.renderIntoDocument(Packet({
+				showInlineDetails: false,
+				data: data
+			}));
+
+			var el = React.findDOMNode(packet);
+
+			expect(el).toBeDefined();
+
+			// NOTE: prior the fix, a long "consoleAPICall" received packet
+			// was wrongly turned into a "div.errorMessage"
+			var errorMessage = el.querySelector(".errorMessage");
+			expect(errorMessage).toEqual(null);
+		});
+	})
+
+});
+
+});

--- a/karma-tests/components/packet-spec.js
+++ b/karma-tests/components/packet-spec.js
@@ -18,74 +18,74 @@ describe("Packet", () => {
     jasmine.addMatchers(ReactMatchers);
   });
 
-	//TODO: currently skipped, until TreeView component is exported from firebug.sdk
+  //TODO: currently skipped, until TreeView component is exported from firebug.sdk
   xit("contains a TreeView for props.data.packet only if props.showInlineDetails is true", () => {
     var packet;
 
-		var data = {
-			type: "receive",
-			size: 0,
-			id: 1,
-			time: new Date("2015-06-09T16:48:50.162Z"),
-			packet: {}
-		};
+    var data = {
+      type: "receive",
+      size: 0,
+      id: 1,
+      time: new Date("2015-06-09T16:48:50.162Z"),
+      packet: {}
+    };
 
-		packet = TestUtils.renderIntoDocument(Packet({
-			showInlineDetails: false,
-			data: data
-		}));
+    packet = TestUtils.renderIntoDocument(Packet({
+      showInlineDetails: false,
+      data: data
+    }));
 
     //TODO: needs TreeView component exported from firebug.sdk
     expect(TreeViewComponent).toBeFoundInReactTree(packet, 0);
 
-		packet = TestUtils.renderIntoDocument(Packet({
-			showInlineDetails: true,
-			data: data
-		}));
+    packet = TestUtils.renderIntoDocument(Packet({
+      showInlineDetails: true,
+      data: data
+    }));
 
-		//TODO: needs TreeView component exported from firebug.sdk
+    //TODO: needs TreeView component exported from firebug.sdk
     expect(TreeViewComponent).toBeFoundInReactTree(packet, 1);
   });
 
   describe("issues", () => {
-		it("#44 - Long packet value breaks the view", () => {
-			var data = {
-				type: "receive",
-				size: 0,
-				id: 1,
-				time: new Date("2015-06-09T16:48:50.162Z"),
-				packet: {
-					error: null,
-					message: {
-						"groupName": "",
-						"columnNumber": 13,
-						"lineNumber": 48,
-						"workerType": "none",
-						"level": "table",
-						"counter": null,
-						"arguments": [],
-						"functionName": "onExecuteTest1"
-					},
-					"type": "consoleAPICall",
-					"from": "server1.conn1.child1/consoleActor2"
-				}
-			};
+    it("#44 - Long packet value breaks the view", () => {
+      var data = {
+        type: "receive",
+        size: 0,
+        id: 1,
+        time: new Date("2015-06-09T16:48:50.162Z"),
+        packet: {
+          error: null,
+          message: {
+            "groupName": "",
+            "columnNumber": 13,
+            "lineNumber": 48,
+            "workerType": "none",
+            "level": "table",
+            "counter": null,
+            "arguments": [],
+            "functionName": "onExecuteTest1"
+          },
+          "type": "consoleAPICall",
+          "from": "server1.conn1.child1/consoleActor2"
+        }
+      };
 
-			var packet = TestUtils.renderIntoDocument(Packet({
-				showInlineDetails: false,
-				data: data
-			}));
+      var packet = TestUtils.renderIntoDocument(Packet({
+        showInlineDetails: false,
+        data: data
+      }));
 
-			var el = React.findDOMNode(packet);
+      var el = React.findDOMNode(packet);
 
-			expect(el).toBeDefined();
+      expect(el).toBeDefined();
 
-			// NOTE: prior the fix, a long "consoleAPICall" received packet
-			// was wrongly turned into a "div.errorMessage"
-			var errorMessage = el.querySelector(".errorMessage");
-			expect(errorMessage).toEqual(null);
-		});
-	})
+      // NOTE: prior the fix, a long "consoleAPICall" received packet
+      // was wrongly turned into a "div.errorMessage"
+      var errorMessage = el.querySelector(".errorMessage");
+      expect(errorMessage).toEqual(null);
+    });
+  });
 
 });
 

--- a/karma-tests/components/packets-toolbar-spec.js
+++ b/karma-tests/components/packets-toolbar-spec.js
@@ -8,10 +8,6 @@ var React = require("react");
 var { TestUtils } = React.addons;
 
 var { PacketsToolbar } = require("components/packets-toolbar");
-var {
-  DropdownButton,
-  MenuItem
-} = require("react-bootstrap");
 
 var packetsToolbar = TestUtils.renderIntoDocument(PacketsToolbar({}));
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,7 @@
 /* eslint quotes:0 */
 
 module.exports = function(config) {
-  
+
   "use strict";
 
   var baseKarmaConfig = {
@@ -68,10 +68,13 @@ module.exports = function(config) {
     console.log("CODE COVERAGE ENABLED");
     config.set({
       coverageReporter: {
-        type: 'html',
-        dir: 'coverage/',
+        reporters: [
+          { type: "html", subdir: "html/" },
+          { type: "text" },
+          { type: "text-summary" }
+        ],
         instrumenters: {
-          istanbul: require("istanbul-harmony")
+          istanbul: require("isparta")
         }
       },
       preprocessors: {

--- a/lib/inspector-actor.js
+++ b/lib/inspector-actor.js
@@ -1,9 +1,13 @@
+
 /* See license.txt for terms of usage */
+
+/* globals exports */
+/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
 
 "use strict";
 
 // Add-on SDK
-const { Cc, Ci, Cu } = require("chrome");
+const { Cu } = require("chrome");
 
 // DevTools
 const { DebuggerServer } = Cu.import("resource://gre/modules/devtools/dbg-server.jsm", {});
@@ -18,15 +22,31 @@ const { method, RetVal, ActorClass, Actor } = protocol;
 // const Trace = getTrace();
 const Trace = {sysout: () => {}};
 
+function dumpFactories(factories) {
+  let result = [];
+
+  let props = Object.getOwnPropertyNames(factories);
+  for (let name of props) {
+    let factory = factories[name];
+    result.push({
+      name: factory.name,
+      prefix: factory._prefix,
+      constructor: factory.constructor ? factory.constructor.name : undefined
+    });
+  }
+
+  return result;
+}
+
 /**
  * Helper actor state watcher.
  */
-function expectState(expectedState, method) {
+function expectState(expectedState, calledMethod) {
   return function(...args) {
     if (this.state !== expectedState) {
       Trace.sysout("actor.expectState; ERROR wrong state, expected '" +
         expectedState + "', but current state is '" + this.state + "'" +
-        ", method: " + method);
+        ", method: " + calledMethod);
 
       let msg = "Wrong State: Expected '" + expectedState + "', but current " +
         "state is '" + this.state + "'";
@@ -133,7 +153,7 @@ var InspectorActor = ActorClass(
       result.actorPool = {
         pool: dumpPool(this.conn._actorPool),
         id: this.conn._actorPool.id
-      }
+      };
     }
 
     result.extraPools = [];
@@ -155,8 +175,8 @@ var InspectorActor = ActorClass(
     return result;
   }, {
     request: {},
-    response: RetVal("json"),
-  }),
+    response: RetVal("json")
+  })
 });
 
 // Helpers
@@ -172,7 +192,7 @@ function dumpPool(pool) {
         typeName: actor.typeName,
         parentID: actor._parentActor ? actor._parentActor.actorID : undefined,
         constructor: actor.constructor ? actor.constructor.name : undefined
-      })
+      });
     });
   } else {
     // xxxHonza: there are actors (classes) stored as pools.
@@ -182,22 +202,6 @@ function dumpPool(pool) {
     result.actorPrefix = pool.actorPrefix;
     result.typeName = pool.typeName;
     result.parentID = pool.parentID;
-  }
-
-  return result;
-}
-
-function dumpFactories(factories) {
-  let result = [];
-
-  let props = Object.getOwnPropertyNames(factories);
-  for (let name of props) {
-    let factory = factories[name];
-    result.push({
-      name: factory.name,
-      prefix: factory._prefix,
-      constructor: factory.constructor ? factory.constructor.name : undefined,
-    });
   }
 
   return result;

--- a/lib/inspector-front.js
+++ b/lib/inspector-front.js
@@ -1,5 +1,8 @@
 /* See license.txt for terms of usage */
 
+/* globals exports, module */
+/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
+
 "use strict";
 
 module.metadata = {
@@ -7,10 +10,10 @@ module.metadata = {
 };
 
 // Add-on SDK
-const { Cc, Ci, Cu } = require("chrome");
+const { Cu } = require("chrome");
 
 // Firebug SDK
-const { Trace, TraceError } = require("firebug.sdk/lib/core/trace.js").get(module.id);
+const { Trace/*, TraceError*/ } = require("firebug.sdk/lib/core/trace.js").get(module.id);
 
 // DevTools
 const { devtools } = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
@@ -42,7 +45,7 @@ var InspectorFront = FrontClass(InspectorActor,
 
   onDetached: function(response) {
     Trace.sysout("inspectorFront.onDetached; ", response);
-  },
+  }
 });
 
 // Helpers

--- a/lib/inspector-service.js
+++ b/lib/inspector-service.js
@@ -1,5 +1,8 @@
 /* See license.txt for terms of usage */
 
+/* globals exports, module */
+/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
+
 "use strict";
 
 module.metadata = {
@@ -8,12 +11,12 @@ module.metadata = {
 
 // Add-on SDK
 const options = require("@loader/options");
-const { Cu, Ci } = require("chrome");
+const { Cu } = require("chrome");
 const { defer, all } = require("sdk/core/promise");
 
 // Firebug SDK
 const { Dispatcher } = require("firebug.sdk/lib/dispatcher");
-const { Trace, TraceError } = require("firebug.sdk/lib/core/trace.js").get(module.id);
+const { Trace/*, TraceError*/ } = require("firebug.sdk/lib/core/trace.js").get(module.id);
 const { Rdp } = require("firebug.sdk/lib/core/rdp.js");
 
 // DevTools
@@ -60,7 +63,7 @@ const InspectorService =
 
   // Toolbox Events
 
-  onToolboxCreated: function(eventId, toolbox) {
+  onToolboxCreated: function(/*eventId, toolbox*/) {
     Trace.sysout("InspectorService.onToolboxCreated;");
   },
 
@@ -68,7 +71,7 @@ const InspectorService =
     Trace.sysout("InspectorService.onToolboxReady;", toolbox);
   },
 
-  onToolboxDestroy: function(eventId, toolbox) {
+  onToolboxDestroy: function(/*eventId, toolbox*/) {
     Trace.sysout("InspectorService.onToolboxDestroy;");
   },
 

--- a/lib/inspector-window.js
+++ b/lib/inspector-window.js
@@ -1,5 +1,8 @@
 /* See license.txt for terms of usage */
 
+/* globals exports, module, FBTrace */
+/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
+
 "use strict";
 
 module.metadata = {
@@ -8,13 +11,13 @@ module.metadata = {
 
 // Add-on SDK
 const self = require("sdk/self");
-const options = require("@loader/options");
-const { Cu, Ci, Cc } = require("chrome");
+/*const options = require("@loader/options");*/
+const { Ci, Cc } = require("chrome");
 const { Class } = require("sdk/core/heritage");
 const { getMostRecentWindow } = require("sdk/window/utils");
 const { openDialog } = require("sdk/window/utils");
 const Events = require("sdk/dom/events");
-const { defer, all } = require("sdk/core/promise");
+const { all } = require("sdk/core/promise");
 const simplePrefs = require("sdk/simple-prefs");
 const { prefs } = simplePrefs;
 
@@ -29,7 +32,7 @@ const { Options } = require("firebug.sdk/lib/core/options.js");
 const { InspectorService } = require("./inspector-service.js");
 
 const nsIFilePicker = Ci.nsIFilePicker;
-const windowType = "RDPInspectorConsole";
+const WINDOW_TYPE = "RDPInspectorConsole";
 const INSPECTOR_XUL_URL = "chrome://rdpinspector/content/inspector-window.xul";
 
 /**
@@ -73,7 +76,7 @@ const InspectorWindow = Class(
   toggle: function() {
     Trace.sysout("InspectorWindow.toggle;", arguments);
 
-    let win = getMostRecentWindow(windowType);
+    let win = getMostRecentWindow(WINDOW_TYPE);
 
     // If the Inspector is already opened, just reuse the window.
     if (win) {
@@ -309,7 +312,6 @@ const InspectorWindow = Class(
   onContentMessage: function(msg) {
     Trace.sysout("InspectorWindow.onContentMessage; " + msg.data.type, msg);
 
-    let result;
     let event = msg.data;
     let args = event.args;
 
@@ -355,7 +357,7 @@ const InspectorWindow = Class(
       bubbles: false,
       cancelable: false,
       data: data,
-      origin: this.url,
+      origin: this.url
     });
   },
 
@@ -370,7 +372,7 @@ const InspectorWindow = Class(
     var event = new contentWindow.MessageEvent(type, {
       bubbles: true,
       cancelable: true,
-      data: data,
+      data: data
     });
 
     contentWindow.dispatchEvent(event);

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,17 +1,17 @@
 /* See license.txt for terms of usage */
 
+/* globals exports, module */
+/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
+
 "use strict";
 
-// Add-on SDK
-const { Cu, Ci } = require("chrome");
-
 // Firebug.SDK
-const { Trace, TraceError } = require("firebug.sdk/lib/core/trace.js").get(module.id);
+const { Trace/*, TraceError*/ } = require("firebug.sdk/lib/core/trace.js").get(module.id);
 const { Locale } = require("firebug.sdk/lib/core/locale.js");
 const { ToolboxChrome } = require("firebug.sdk/lib/toolbox-chrome.js");
 
 // RDP Inspector
-const { StartButton } = require("./start-button.js");
+require("./start-button.js");
 const { ToolboxOverlay } = require("./toolbox-overlay.js");
 
 // Localization files
@@ -23,7 +23,7 @@ Locale.registerStringBundle("chrome://rdpinspector-firebug.sdk/locale/reps.prope
  * Extension's entry point. Read MDN to learn more about Add-on SDK:
  * https://developer.mozilla.org/en-US/Add-ons/SDK
  */
-function main(options, callbacks) {
+function main(options/*, callbacks*/) {
   Trace.sysout("main;", options);
 
   ToolboxChrome.initialize(options);

--- a/lib/start-button.js
+++ b/lib/start-button.js
@@ -1,5 +1,8 @@
 /* See license.txt for terms of usage */
 
+/* globals exports, module */
+/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
+
 "use strict";
 
 module.metadata = {
@@ -38,6 +41,50 @@ const { ToolboxOverlay } = require("./toolbox-overlay");
 
 const startButtonId = "rdp-inspector-start-button";
 
+// Helpers
+
+function showToolbox(toolId) {
+  let browser = getMostRecentBrowserWindow();
+  let tab = browser.gBrowser.mCurrentTab;
+  let target = devtools.TargetFactory.forTab(tab);
+  return gDevTools.showToolbox(target, toolId);
+}
+
+function getToolboxWhenReady(toolId) {
+  let deferred = defer();
+  showToolbox(toolId).then(toolbox => {
+    return deferred.resolve(toolbox);
+  });
+  return deferred.promise;
+}
+
+function cancelEvent(event) {
+  event.stopPropagation();
+  event.preventDefault();
+}
+
+/**
+ * This object represents a wrapper for start button node that is
+ * used as an anchor for Notification Panel object (displayed when
+ * the extension is installed for the first time).
+ *
+ * Note that passing directly a DOM node to Panel.show() method is
+ * an unsupported feature that will be soon replaced.
+ * See: https://bugzilla.mozilla.org/show_bug.cgi?id=878877
+ */
+var StartButtonAnchor = Class(
+/** @lends StartButtonAnchor */
+{
+  initialize: function(button) {
+    this.node = button;
+  }
+});
+
+// getNodeView is used by the SDK panel to get the target anchor node.
+getNodeView.define(StartButtonAnchor, anchor => {
+  return anchor.node;
+});
+
 /**
  * This object represents a button that is automatically displayed
  * in the main Firefox toolbar after the extension is installed.
@@ -62,7 +109,7 @@ var StartButton =
     });
   },
 
-  shutdown: function(reason) {
+  shutdown: function(/*reason*/) {
     CustomizableUI.destroyWidget(startButtonId);
   },
 
@@ -96,7 +143,7 @@ var StartButton =
 
   // Menu Actions
 
-  getMenuItems: function(win) {
+  getMenuItems: function(/*win*/) {
     let items = [];
 
     items.push({
@@ -167,7 +214,7 @@ var StartButton =
       if (!overlay) {
         TraceError.sysout("startButton.onToggleRdpInspector; ERROR " +
           " No overlay: " + overlayId, context);
-        return;
+        return null;
       }
 
       let win = overlay.toggleInspector();
@@ -222,51 +269,7 @@ var StartButton =
     let browser = getMostRecentBrowserWindow();
     openTab(browser, options.manifest.forum);
   }
-}
-
-// Helpers
-
-function getToolboxWhenReady(toolId) {
-  let deferred = defer();
-  showToolbox(toolId).then(toolbox => {
-    return deferred.resolve(toolbox);
-  });
-  return deferred.promise;
-}
-
-function showToolbox(toolId) {
-  let browser = getMostRecentBrowserWindow();
-  let tab = browser.gBrowser.mCurrentTab;
-  let target = devtools.TargetFactory.forTab(tab);
-  return gDevTools.showToolbox(target, toolId);
-}
-
-function cancelEvent(event) {
-  event.stopPropagation();
-  event.preventDefault();
-}
-
-/**
- * This object represents a wrapper for start button node that is
- * used as an anchor for Notification Panel object (displayed when
- * the extension is installed for the first time).
- *
- * Note that passing directly a DOM node to Panel.show() method is
- * an unsupported feature that will be soon replaced.
- * See: https://bugzilla.mozilla.org/show_bug.cgi?id=878877
- */
-var StartButtonAnchor = Class(
-/** @lends StartButtonAnchor */
-{
-  initialize: function(button) {
-    this.node = button;
-  },
-});
-
-// getNodeView is used by the SDK panel to get the target anchor node.
-getNodeView.define(StartButtonAnchor, anchor => {
-  return anchor.node;
-});
+};
 
 // Registration
 Dispatcher.register(StartButton);

--- a/lib/toolbox-overlay.js
+++ b/lib/toolbox-overlay.js
@@ -1,5 +1,8 @@
 /* See license.txt for terms of usage */
 
+/* globals exports, module */
+/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
+
 "use strict";
 
 module.metadata = {
@@ -7,15 +10,14 @@ module.metadata = {
 };
 
 // Add-on SDK
-const options = require("@loader/options");
-const { Cu, Ci } = require("chrome");
+/*const options = require("@loader/options");*/
 const { Class } = require("sdk/core/heritage");
 const simplePrefs = require("sdk/simple-prefs");
 const { prefs } = simplePrefs;
 
 // Firebug SDK
-const { Trace, TraceError } = require("firebug.sdk/lib/core/trace.js").get(module.id);
-const { Locale } = require("firebug.sdk/lib/core/locale.js");
+const { Trace/*, TraceError*/ } = require("firebug.sdk/lib/core/trace.js").get(module.id);
+/*const { Locale } = require("firebug.sdk/lib/core/locale.js");*/
 const { ToolboxOverlay: ToolboxOverlayBase } = require("firebug.sdk/lib/toolbox-overlay.js");
 const { TransportObserver } = require("./transport-observer.js");
 const { Arr } = require("firebug.sdk/lib/core/array.js");
@@ -58,7 +60,7 @@ const ToolboxOverlay = Class(
     this.onReceivePacket = this.onReceivePacket.bind(this);
 
     // Initialize transport observer
-    let remotePromise = this.toolbox.target.makeRemote();
+    this.toolbox.target.makeRemote();
     let client = this.toolbox.target.client;
     this.transportObserver = new TransportObserver({client: client});
     this.transportObserver.addListener(this);
@@ -102,7 +104,7 @@ const ToolboxOverlay = Class(
     return {
       removedPackets: this.removedPackets,
       packets: this.packetCache
-    }
+    };
   },
 
   addTransportListener: function(listener) {
@@ -177,7 +179,7 @@ const ToolboxOverlay = Class(
     this.inspector.toggle();
 
     return this.inspector;
-  },
+  }
 });
 
 // Exports from this module

--- a/lib/transport-observer.js
+++ b/lib/transport-observer.js
@@ -1,5 +1,8 @@
 /* See license.txt for terms of usage */
 
+/* globals exports, module */
+/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
+
 "use strict";
 
 module.metadata = {
@@ -11,8 +14,7 @@ const { Class } = require("sdk/core/heritage");
 const { EventTarget } = require("sdk/event/target");
 
 // Firebug SDK
-const { Trace, TraceError } = require("firebug.sdk/lib/core/trace.js").get(module.id);
-const { System } = require("firebug.sdk/lib/core/system.js");
+const { Trace/*, TraceError*/ } = require("firebug.sdk/lib/core/trace.js").get(module.id);
 const { Arr } = require("firebug.sdk/lib/core/array.js");
 
 /**
@@ -75,13 +77,13 @@ const TransportObserver = Class(
     });
   },
 
-  startBulkSend: function(eventId, header) {
+  startBulkSend: function(/*eventId, header*/) {
   },
 
-  onBulkPacket: function(eventId, packet) {
+  onBulkPacket: function(/*eventId, packet*/) {
   },
 
-  onClosed: function(eventId, status) {
+  onClosed: function(/*eventId, status*/) {
   },
 
   // Listeners
@@ -92,7 +94,7 @@ const TransportObserver = Class(
 
   removeListener: function(listener) {
     Arr.remove(this.listeners, listener);
-  },
+  }
 });
 
 // Exports from this module

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   "scripts": {
     "test": "npm run karma-tests && npm run jpm-tests",
     "karma-tests": "karma start --single-run --reporters spec",
-    "travis-ci": "npm run karma-tests && npm run jpm-tests -- -v",
+    "karma-coverage": "CODE_COVERAGE=true npm run karma-tests -- --reporters spec,coverage",
     "watch-karma-tests": "karma start --no-single-run --reporters spec --auto-watch",
-    "watch-karma-coverage": "COVERAGE=true npm run watch-karma-tests",
-    "jpm-tests": "jpm test"
+    "watch-karma-coverage": "CODE_COVERAGE=true npm run watch-karma-tests",
+    "jpm-tests": "jpm test",
+    "travis-ci": "npm run jpm-tests -- -v && npm run karma-coverage"
   },
   "engines": {
     "firefox": ">=38.0 <=40.0"
@@ -72,7 +73,7 @@
   },
   "devDependencies": {
     "eslint": "^0.21.0",
-    "istanbul-harmony": "git://github.com/fengmk2/istanbul#harmony-0.3.x",
+    "isparta": "^3.0.3",
     "jasmine-core": "^2.3.2",
     "karma": "^0.12.31",
     "karma-cli": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "watch-karma-coverage": "CODE_COVERAGE=true npm run watch-karma-tests",
     "jpm-tests": "jpm test",
     "travis-ci": "npm run jpm-tests -- -v && npm run karma-coverage && npm run lint",
-    "lint-content": "eslint data/inspector",
+    "lint-content": "eslint data/inspector && eslint karma-tests/",
     "lint-addon": "eslint --env node lib",
     "lint": "npm run lint-content && npm run lint-addon"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "watch-karma-tests": "karma start --no-single-run --reporters spec --auto-watch",
     "watch-karma-coverage": "CODE_COVERAGE=true npm run watch-karma-tests",
     "jpm-tests": "jpm test",
-    "travis-ci": "npm run jpm-tests -- -v && npm run karma-coverage",
+    "travis-ci": "npm run jpm-tests -- -v && npm run karma-coverage && npm run lint",
     "lint-content": "eslint data/inspector",
     "lint-addon": "eslint --env node lib",
     "lint": "npm run lint-content && npm run lint-addon"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "watch-karma-tests": "karma start --no-single-run --reporters spec --auto-watch",
     "watch-karma-coverage": "CODE_COVERAGE=true npm run watch-karma-tests",
     "jpm-tests": "jpm test",
-    "travis-ci": "npm run jpm-tests -- -v && npm run karma-coverage"
+    "travis-ci": "npm run jpm-tests -- -v && npm run karma-coverage",
+    "lint-content": "eslint data/inspector",
+    "lint-addon": "eslint --env node lib",
+    "lint": "npm run lint-content && npm run lint-addon"
   },
   "engines": {
     "firefox": ">=38.0 <=40.0"


### PR DESCRIPTION
In this pull request (currently based on the PR #46) I tried to fix all the eslint errors and warnings and tweak the .eslintrc (or in eslint comments for workaround differences between the javascript code in data/ and lib/ dirs).

The goal is to detect as much coding styling errors/warnings as possible during the test build on travis-ci.

Unfortunately there are a bunch of lint errors I had to disable because currently used in our code:

- **indent** (required to enable the current indentation style in data/inspector/**/*.js, unfortunately **no-mixed-spaces-and-tabs** is not as much useful as **indent**)
- **linebreak-style** (do not warn on differences between unix and windows default line break style)

- **new-cap** (required to enable the current React elements creation syntax)
- **eqeqeq** (warns on a lot of "!=" and "==" usages )
   