### PR TITLE
add eslint-plugin-no-tabs and eslint-plugin-react

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,17 @@
 {
+  "plugins": [
+    "no-tabs",
+    "react"
+  ],
   "rules": {
     "no-mixed-spaces-and-tabs": [2],
     "quotes": [2, "double"],
     "semi": [1, "always"],
+
+    "no-tabs/at-all": [2],
+
+    "react/display-name": 2,
+    "react/prop-types": 0,
 
     "indent": [0, 2],
     "linebreak-style": [0],

--- a/data/inspector/components/packets-summary.js
+++ b/data/inspector/components/packets-summary.js
@@ -20,6 +20,8 @@ const { DIV } = Reps.DOM;
  * @template Helper template responsible for rendering a tooltip.
  */
 const TextWithTooltip = React.createFactory(React.createClass({
+  displayName: "TextWithTooltip",
+
   render: function() {
     var tooltip = Tooltip({}, this.props.tooltip);
     return (

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
   },
   "devDependencies": {
     "eslint": "^0.21.0",
+    "eslint-plugin-no-tabs": "git://github.com/rpl/eslint-plugin-no-tabs",
+    "eslint-plugin-react": "git://github.com/rpl/eslint-plugin-react#fix/displayName-and-propTypes-on-jsx-false",
     "isparta": "^3.0.3",
     "jasmine-core": "^2.3.2",
     "karma": "^0.12.31",


### PR DESCRIPTION
In this PR I'm experimenting usage of eslint plugins:

- [eslint-plugin-no-tabs](http://github.com/rpl/eslint-plugin-no-tabs) is a new minimal plugin which prevents any tab whitespace in the javascript sources (I've create this new plugin as a temporary replacement for the currently disabled 'indent' eslint rule)
- [eslint-plugin-react](https://github.com/rpl/eslint-plugin-react/tree/fix/displayName-and-propTypes-on-jsx-false) is a plugin with a bunch of useful linting rules related to React (I'm currently using my fork of the original repo because it didn't recognized all the components when jsx is not used, we can turn it into the standard one once the fix will be merged)

Then, with the **react/display-name** eslint rule active, I've found and fixed a missing displayName in a packets-summary React Component. 
