### PR TITLE
Turn options inside PacketsPanel toolbar into checkbox menu items

### DIFF
--- a/chrome/locale/en-US/inspector.properties
+++ b/chrome/locale/en-US/inspector.properties
@@ -4,21 +4,20 @@ rdpInspector.tab.Packets=Packets
 rdpInspector.tab.Actors=Actors
 
 # LOCALIZATION NOTE (rdpInspector.option.showInlineDetails,
-# rdpInspector.option.showInlineDetails): Label for an
-# option that can be set within the Packets tab. If set to true
+# rdpInspector.option.showInlineDetails): Label and
+# tooltip for an option that can be set within the Packets tab. If set to true
 # every packet display inline preview of packet properties (collapsed
 # by default)
 rdpInspector.option.showInlineDetails=Show Packet Details Inline
-rdpInspector.option.hideInlineDetails=Hide Packet Details Inline
+rdpInspector.option.showInlineDetails.tip=Show a detailed tree view of the Packet content.
 
-# LOCALIZATION NOTE (rdpInspector.option.packetCacheEnabled, rdpInspector.options.packetCacheDisabled): Label for an
-# option that can be set within the Packets tab. If set to true
+# LOCALIZATION NOTE (rdpInspector.option.packetCacheEnabled, rdpInspector.options.packetCacheEnabled.tip): Label and
+# tooltip for an option that can be set within the Packets tab. If set to true
 # the inspector caches packets that are sent/received before the
 # inspector window is opened (to see also packets that happens
 # at the very beginning)
-rdpInspector.option.packetCacheEnabled=Cache packets before the inspector is opened
-rdpInspector.option.packetCacheDisabled=Do not cache packets before the inspector is opened
-
+rdpInspector.option.packetCacheEnabled=Packet Cache
+rdpInspector.option.packetCacheEnabled.tip=Store packets in a cache before the console is opened.
 
 # LOCALIZATION NOTE (rdpInspector.cmd.clear): Label for a toolbar button
 # in the Packets tab. This command clears the packet list.

--- a/data/inspector/components/packets-toolbar.js
+++ b/data/inspector/components/packets-toolbar.js
@@ -14,9 +14,11 @@ var ButtonToolbar = React.createFactory(ReactBootstrap.ButtonToolbar);
 var Button = React.createFactory(ReactBootstrap.Button);
 var DropdownButton = React.createFactory(ReactBootstrap.DropdownButton);
 var MenuItem = React.createFactory(ReactBootstrap.MenuItem);
+var OverlayTrigger = React.createFactory(ReactBootstrap.OverlayTrigger);
+var Tooltip = React.createFactory(ReactBootstrap.Tooltip);
 
 const { Reps } = require("reps/reps");
-const { SPAN } = Reps.DOM;
+const { SPAN, INPUT } = Reps.DOM;
 
 /**
  * @template This object represents a template for a toolbar displayed
@@ -31,13 +33,12 @@ var PacketsToolbar = React.createClass({
     var { showInlineDetails, packetCacheEnabled } = this.props;
 
     var labels = {};
-    labels.inlineDetails = showInlineDetails ?
-      Locale.$STR("rdpInspector.option.hideInlineDetails") :
-      Locale.$STR("rdpInspector.option.showInlineDetails");
+    labels.inlineDetails = Locale.$STR("rdpInspector.option.showInlineDetails");
+    labels.cachePackets = Locale.$STR("rdpInspector.option.packetCacheEnabled");
 
-    labels.cachePackets = packetCacheEnabled ?
-      Locale.$STR("rdpInspector.option.packetCacheDisabled") :
-      Locale.$STR("rdpInspector.option.packetCacheEnabled");
+    var tooltips = {};
+    tooltips.inlineDetails = Locale.$STR("rdpInspector.option.showInlineDetails.tip");
+    tooltips.cachePackets = Locale.$STR("rdpInspector.option.packetCacheEnabled.tip");
 
     var paused = this.props.paused;
     var pauseClassName = paused ? "btn-warning" : "";
@@ -54,13 +55,15 @@ var PacketsToolbar = React.createClass({
           bsSize: "xsmall", title: Locale.$STR("rdpInspector.menu.Options"),
           className: "pull-right", ref: "options"
         },
-          MenuItem({key: "inlineDetails", onClick: this.onShowInlineDetails,
-            checked: showInlineDetails},
-            labels.inlineDetails
+          OverlayTrigger({placement: "bottom", overlay: Tooltip({}, tooltips.inlineDetails)},
+            MenuItem({key: "inlineDetails", ref: "optionShowInlineDetails", onClick: this.onShowInlineDetails},
+              INPUT({type: "checkbox", checked: showInlineDetails}), labels.inlineDetails
+            )
           ),
-          MenuItem({key: "cachePackets", onClick: this.onCachePackets,
-            checked: packetCacheEnabled},
-            labels.cachePackets
+          OverlayTrigger({placement: "bottom", overlay: Tooltip({}, tooltips.cachePackets)},
+            MenuItem({key: "cachePackets", ref: "optionCachePackets", onClick: this.onCachePackets},
+              INPUT({type: "checkbox", checked: packetCacheEnabled}), labels.cachePackets
+            )
           )
         ),
         Button({bsSize: "xsmall", onClick: this.onClear},
@@ -96,12 +99,10 @@ var PacketsToolbar = React.createClass({
 
   onShowInlineDetails: function() {
     this.props.actions.onShowInlineDetails();
-    this.refs.options.setDropdownState(false);
   },
 
   onCachePackets: function() {
     this.props.actions.onPacketCacheEnabled();
-    this.refs.options.setDropdownState(false);
   },
 
   onPause: function(/*event*/) {

--- a/data/inspector/css/toolbar.css
+++ b/data/inspector/css/toolbar.css
@@ -21,3 +21,20 @@
   line-height: 1.0;
   font-size: 12px;
 }
+
+.toolbar input[type="checkbox"] {
+  margin-right: 8px;
+}
+
+/******************************************************************************/
+/* Tooltip */
+
+.tooltip .tooltip-inner {
+  background-color: #EEE1B3;
+  color: black;
+  max-width: 300px;
+}
+.tooltip.bottom .tooltip-arrow {
+  border-bottom-color: #EEE1B3;
+  color: black;
+}

--- a/karma-tests/components/packets-toolbar-spec.js
+++ b/karma-tests/components/packets-toolbar-spec.js
@@ -28,7 +28,7 @@ describe("PacketsToolbar", () => {
     expect(packetsToolbar.refs.fileMenu).toBeDefined();
   });
 
-  describe("its File DropdownButton Menu", () => {
+  describe("File DropdownButton Menu", () => {
     // spy actions that should be called
     var actions = {
       loadPacketsFromFile: jasmine.createSpy("loadPacketsFromFile"),
@@ -60,5 +60,37 @@ describe("PacketsToolbar", () => {
     });
   });
 
+  describe("Options DropdownButton Menu", () => {
+    // spy actions that should be called
+    var actions = {
+      onShowInlineDetails: jasmine.createSpy("onShowInlineDetails"),
+      onPacketCacheEnabled: jasmine.createSpy("onPacketCacheEnabled")
+    };
+
+    beforeAll(() => {
+      packetsToolbar = TestUtils.renderIntoDocument(PacketsToolbar({
+        actions: actions
+      }));
+    });
+
+    it("contains a 'Show Inline Details' and 'Packets Cache' MenuItems", () => {
+      // load and save menuitems should be defined
+      expect(packetsToolbar.refs.optionShowInlineDetails).toBeDefined();
+      expect(packetsToolbar.refs.optionCachePackets).toBeDefined();
+    });
+
+    it("calls props.actions.onShowInlineDetails on 'Show Inline Details' clicks", () => {
+      var node = React.findDOMNode(packetsToolbar.refs.optionShowInlineDetails);
+      TestUtils.Simulate.click(node);
+      expect(actions.onShowInlineDetails).toHaveBeenCalled();
+    });
+
+    it("calls props.actions.onPacketCacheEnabled on 'Packet Cache' clicks", () => {
+      var node = React.findDOMNode(packetsToolbar.refs.optionCachePackets);
+      TestUtils.Simulate.click(node);
+      expect(actions.onPacketCacheEnabled).toHaveBeenCalled();
+    });
+  });
 });
+
 });


### PR DESCRIPTION
This PR (as a follow up of #40) turns the options inside PacketsPanel toolbar into checkbox menu items (to match the behaviour of the same options inside the start button menu popup)

![rdp-inspector-checkbox-options](https://cloud.githubusercontent.com/assets/11484/8258807/5591f3f6-16b8-11e5-9934-6e6a235c60cf.png)


