### PR TITLE
Feature: "Edit and Resent" action in Packet context menu 

### DIFF
--- a/data/inspector/components/main-tabbed-area.js
+++ b/data/inspector/components/main-tabbed-area.js
@@ -72,6 +72,7 @@ var MainTabbedArea = React.createClass({
             packets: this.state.packets,
             actions: this.props.actions,
             selectedPacket: this.state.selectedPacket,
+            editedPacket: this.state.editedPacket,
             searchFilter: this.state.searchFilter,
             showInlineDetails: this.state.showInlineDetails,
             packetCacheEnabled: this.state.packetCacheEnabled,

--- a/data/inspector/components/packet-editor.js
+++ b/data/inspector/components/packet-editor.js
@@ -59,7 +59,7 @@ var PacketEditor = React.createClass({
 
   getInitialState: function() {
     return {
-      selectedPacket: null,
+      editedPacket: null,
       defaultData: {
         to: "root",
         type: "requestTypes"
@@ -69,12 +69,12 @@ var PacketEditor = React.createClass({
 
   componentWillReceiveProps: function(nextProps) {
     this.setState({
-      selectedPacket: nextProps.selectedPacket
+      editedPacket: nextProps.editedPacket
     });
   },
 
   render: function() {
-    var selectedPacket = this.state.selectedPacket || this.props.selectedPacket;
+    var editedPacket = this.state.editedPacket || this.props.editedPacket;
     var { actorIDs } = this.props;
 
     return (
@@ -90,7 +90,7 @@ var PacketEditor = React.createClass({
           TreeEditorView({
             ref: "editor",
             key: "packet-editor",
-            data: selectedPacket && selectedPacket.to ? selectedPacket : null,
+            data: editedPacket,
             defaultData: this.state.defaultData,
             handleAutocompletion: (suggestionType, keyPath, value) => {
               if (!actorIDs && suggestionType != "value") {

--- a/data/inspector/components/packet.js
+++ b/data/inspector/components/packet.js
@@ -92,14 +92,16 @@ var Packet = React.createClass({
             )
           ),
           this.state && this.state.contextMenu &&
-          UL({className: "dropdown-menu", role: "menu", ref: "dropdownMenu",
+          UL({className: "dropdown-menu", role: "menu", ref: "contextMenu",
             onMouseLeave: this.onContextMenuMouseLeave,
             style: {
               display: "block",
               top: this.state.contextMenuTop,
               left: this.state.contextMenuLeft
             }},
-            LI({role: "presentation"}, A({ onClick: this.onEditAndResendClick}, "Edit and Resend"))
+            LI({role: "presentation"},
+              A({ref: "editAndResendAction", onClick: this.onEditAndResendClick},
+                "Edit and Resend"))
           )
         )
       );

--- a/data/inspector/components/packets-panel.js
+++ b/data/inspector/components/packets-panel.js
@@ -55,6 +55,7 @@ var PacketsPanel = React.createClass({
     var rightPanel = DIV({className: "sidePanel"},
       PacketsSidebar({
         selectedPacket: this.props.selectedPacket,
+        editedPacket: this.props.editedPacket,
         actions: this.props.actions,
         actorIDs: this.props.actorIDs
       })

--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -37,9 +37,14 @@ var PacketsSidebar = React.createClass({
     });
   },
 
-  componentWillReceiveProps: function(/*nextProps*/) {
-    // TODO: it would be nice reset activeKey to the "Packet" Detail sidebar
-    // but only when the parent component pass a new selectedPacket
+  componentWillReceiveProps: function(nextProps) {
+    var { editedPacket: prevEditedPacket } = this.props;
+    var { editedPacket } = nextProps;
+
+    // switch to the Packet Editor when then editedPacket changes
+    if (prevEditedPacket != editedPacket) {
+      this.onTabSelected(2);
+    }
   },
 
   render: function() {
@@ -55,7 +60,8 @@ var PacketsSidebar = React.createClass({
         TabPane({eventKey: 2, tab: "Send Packet"},
           PacketEditor({
             actions: this.props.actions,
-            actorIDs: this.props.actorIDs
+            actorIDs: this.props.actorIDs,
+            editedPacket: this.props.editedPacket
           })
         )
       )

--- a/data/inspector/main.js
+++ b/data/inspector/main.js
@@ -32,6 +32,13 @@ var actions = {
   },
 
   /**
+   * Edit packet and resend it from the side bar.
+   */
+  editPacket: function(packet) {
+    theApp.setState({editedPacket: packet});
+  },
+
+  /**
    * Remove all packets from the packet list.
    */
   clear: function() {

--- a/karma-tests/components/packet-spec.js
+++ b/karma-tests/components/packet-spec.js
@@ -47,6 +47,49 @@ describe("Packet", () => {
     expect(TreeViewComponent).toBeFoundInReactTree(packet, 1);
   });
 
+  describe("context menu actions", () => {
+    it("has 'Edit and Resent' action in the sent packet's context menu", () => {
+      var packetData = {
+        "type": "fakeSentPacket",
+        "to": "server1.conn1.child1/fakeActor2"
+      };
+      var data = {
+        type: "send",
+        id: 1,
+        time: new Date("2015-06-09T16:48:50.162Z"),
+        packet: packetData,
+        size: JSON.stringify(packetData).length
+      };
+
+      var actions = {
+        editPacket: jasmine.createSpy("editPacket"),
+        selectPacket: jasmine.createSpy("selectPacket")
+      };
+
+      var packet = TestUtils.renderIntoDocument(Packet({
+        showInlineDetails: false,
+        data: data,
+        actions: actions
+      }));
+
+      expect(packet.refs.contextMenu).not.toBeDefined();
+
+      var el = React.findDOMNode(packet);
+      TestUtils.Simulate.contextMenu(el);
+
+      // right clicking a packet opens a context menu and
+      // select the packet
+      expect(actions.selectPacket).toHaveBeenCalled();
+      expect(packet.refs.contextMenu).toBeDefined();
+      expect(packet.refs.editAndResendAction).toBeDefined();
+
+      // clicking on the 'Edit and Resend' action
+      var actionEl = React.findDOMNode(packet.refs.editAndResendAction);
+      TestUtils.Simulate.click(actionEl);
+      expect(actions.editPacket).toHaveBeenCalled();
+    });
+  });
+
   describe("issues", () => {
     it("#44 - Long packet value breaks the view", () => {
       var data = {

--- a/karma-tests/components/packets-sidebar-spec.js
+++ b/karma-tests/components/packets-sidebar-spec.js
@@ -1,0 +1,54 @@
+/* See license.txt for terms of usage */
+/* eslint-env jasmine */
+
+define(function (require) {
+
+"use strict";
+
+var React = require("react");
+var { TestUtils } = React.addons;
+
+var { PacketsSidebar } = require("components/packets-sidebar");
+var ReactMatchers = require("karma-tests/custom-react-matchers");
+
+describe("PacketsSidebar", () => {
+  beforeAll(() => {
+    jasmine.addMatchers(ReactMatchers);
+  });
+
+  describe("active sidebar auto switch", () => {
+    it("switch to the editor tab on new editedPacket in nextProps", () => {
+      var packetData = {
+        "type": "fakeSentPacket",
+        "to": "server1.conn1.child1/fakeActor2"
+      };
+      var data = {
+        type: "send",
+        id: 1,
+        time: new Date("2015-06-09T16:48:50.162Z"),
+        packet: packetData,
+        size: JSON.stringify(packetData).length
+      };
+
+      var actions = {};
+
+      var packetsSidebar = TestUtils.renderIntoDocument(PacketsSidebar({
+        selectedPacket: null,
+        editedPacket: null,
+        actions: actions
+      }));
+
+      expect(packetsSidebar.state.activeKey).toEqual(1);
+
+      // re-render with an editedPacket selected
+      packetsSidebar = React.render(PacketsSidebar({
+        editedPacket: data
+      }), React.findDOMNode(packetsSidebar).parentNode);
+
+      expect(packetsSidebar.state.activeKey).toEqual(2);
+    });
+  });
+
+});
+
+});

--- a/karma-tests/lib/firebug-sdk-shims.js
+++ b/karma-tests/lib/firebug-sdk-shims.js
@@ -25,6 +25,12 @@ window.Str = {
   formatSize: function(str) { return str; }
 };
 
+window.Trace = {
+  sysout: function(...args) {
+    console.log.apply(console, args);
+  }
+}
+
 // set the theme-firebug class on the body element
 document.body.setAttribute("class", "theme-firebug");
 


### PR DESCRIPTION
This PR reintroduces the "Edit and Resend Packet" feature (which will fix #45).

The new behaviour is:

- right-clicking on a *Sent* packet opens a context menu
- clicking on the *Edit and Resend* action from the context menu will:
  - set the packet in the ```PacketEditor```
  - switch the sidebar to the *Send Packet* tab 
    (currently only if the edited packet is different from the previously edited packet)

Working on testing this feature I found an issue pointed out by a React warning which needs to be fixed in the firebug.sdk dependency (opened as PR firebug/firebug.sdk#8)

![rdp-inspector-editandresend-context-menu-action](https://cloud.githubusercontent.com/assets/11484/8267393/6cf2c0c2-1760-11e5-936e-04484539943b.gif)
