### PR TITLE
Tweaks on packet context menu and auto-switching to packet editor sidebar tab 

### DIFF
--- a/data/inspector/components/packet.js
+++ b/data/inspector/components/packet.js
@@ -157,8 +157,8 @@ var Packet = React.createClass({
 
     this.setState({
       contextMenu: true,
-      contextMenuTop: event.clientY,
-      contextMenuLeft: event.clientX
+      contextMenuTop: event.clientY - 16,
+      contextMenuLeft: event.clientX - 16
     });
     this.props.actions.selectPacket(this.props.data.packet);
   },

--- a/data/inspector/components/packets-sidebar.js
+++ b/data/inspector/components/packets-sidebar.js
@@ -37,14 +37,16 @@ var PacketsSidebar = React.createClass({
     });
   },
 
-  componentWillReceiveProps: function(nextProps) {
-    var { editedPacket: prevEditedPacket } = this.props;
-    var { editedPacket } = nextProps;
+  componentDidMount: function() {
+    window.addEventListener("rdpinspector:switchToPacketEditorTab", this.onSwitchToPacketEditorTab);
+  },
 
-    // switch to the Packet Editor when then editedPacket changes
-    if (prevEditedPacket != editedPacket) {
-      this.onTabSelected(2);
-    }
+  componentWillUnmount: function() {
+    window.removeEventListener(this.onSwitchToPacketEditorTab);
+  },
+
+  onSwitchToPacketEditorTab: function() {
+    this.setState({ activeKey: 2 });
   },
 
   render: function() {

--- a/data/inspector/main.js
+++ b/data/inspector/main.js
@@ -36,6 +36,7 @@ var actions = {
    */
   editPacket: function(packet) {
     theApp.setState({editedPacket: packet});
+    window.dispatchEvent(new CustomEvent("rdpinspector:switchToPacketEditorTab"));
   },
 
   /**

--- a/karma-tests/components/packets-sidebar-spec.js
+++ b/karma-tests/components/packets-sidebar-spec.js
@@ -17,7 +17,7 @@ describe("PacketsSidebar", () => {
   });
 
   describe("active sidebar auto switch", () => {
-    it("switch to the editor tab on new editedPacket in nextProps", () => {
+    it("switch to the editor tab on 'rdpinspector:switchToPacketEditorTab' DOM event", () => {
       var packetData = {
         "type": "fakeSentPacket",
         "to": "server1.conn1.child1/fakeActor2"
@@ -34,16 +34,13 @@ describe("PacketsSidebar", () => {
 
       var packetsSidebar = TestUtils.renderIntoDocument(PacketsSidebar({
         selectedPacket: null,
-        editedPacket: null,
+        editedPacket: data,
         actions: actions
       }));
 
       expect(packetsSidebar.state.activeKey).toEqual(1);
 
-      // re-render with an editedPacket selected
-      packetsSidebar = React.render(PacketsSidebar({
-        editedPacket: data
-      }), React.findDOMNode(packetsSidebar).parentNode);
+      window.dispatchEvent(new CustomEvent("rdpinspector:switchToPacketEditorTab"));
 
       expect(packetsSidebar.state.activeKey).toEqual(2);
     });


### PR DESCRIPTION
This PR introduces two small changes to polish the "Edit and Resend" feature from a User POV:

- ensure the sidebar will always be switched to the editor tab when the user click on the "Edit and Resend" action (currently by subscribing a custom "rdpinspector:switchToPacketEditorTab" DOM Event, which is not elegant from a React point of view and it should be changed once we change how we push the app state down in the React components tree)

- ensure the Packet context menu will be hidden on mouse leave (by positioning the context menu to ensure the mouse pointer is initially inside the opened context menu)