### PR TITLE
Packets and Actors filtering should be case insensitive

### DIFF
--- a/data/inspector/components/actors-panel.js
+++ b/data/inspector/components/actors-panel.js
@@ -149,7 +149,8 @@ var PoolTable = React.createFactory(React.createClass({
     var actors = this.props.pool;
     for (var i in actors) {
       if (this.props.searchFilter &&
-          JSON.stringify(actors[i]).indexOf(this.props.searchFilter) < 0) {
+          JSON.stringify(actors[i]).toLowerCase()
+              .indexOf(this.props.searchFilter.toLowerCase()) < 0) {
         // filter out packets which don't match the filter
         continue;
       }
@@ -219,7 +220,8 @@ var FactoryTable = React.createFactory(React.createClass({
     var factories = this.props.factories;
     for (var i in factories) {
       if (this.props.searchFilter &&
-          JSON.stringify(factories[i]).indexOf(this.props.searchFilter) < 0) {
+          JSON.stringify(factories[i]).toLowerCase()
+              .indexOf(this.props.searchFilter.toLowerCase()) < 0) {
         // filter out packets which don't match the filter
         continue;
       }

--- a/data/inspector/components/factories.js
+++ b/data/inspector/components/factories.js
@@ -47,7 +47,8 @@ var FactoryTable = React.createFactory(React.createClass({
     var factories = this.props.factories;
     for (var i in factories) {
       if (this.props.searchFilter &&
-          JSON.stringify(factories[i]).indexOf(this.props.searchFilter) < 0) {
+          JSON.stringify(factories[i]).toLowerCase()
+              .indexOf(this.props.searchFilter.toLowerCase()) < 0) {
         // filter out packets which don't match the filter
         continue;
       }

--- a/data/inspector/components/packet-list.js
+++ b/data/inspector/components/packet-list.js
@@ -79,7 +79,7 @@ var PacketList = React.createClass({
       }
 
       // Filter out packets which don't match the search token.
-      if (filter && JSON.stringify(packet).indexOf(filter) < 0) {
+      if (filter && JSON.stringify(packet).toLowerCase().indexOf(filter.toLowerCase()) < 0) {
         continue;
       }
 

--- a/data/inspector/components/pools.js
+++ b/data/inspector/components/pools.js
@@ -49,7 +49,8 @@ var PoolTable = React.createFactory(React.createClass({
     var actors = this.props.pool;
     for (var i in actors) {
       if (this.props.searchFilter &&
-          JSON.stringify(actors[i]).indexOf(this.props.searchFilter) < 0) {
+          JSON.stringify(actors[i]).toLowerCase()
+              .indexOf(this.props.searchFilter.toLowerCase()) < 0) {
         // filter out packets which don't match the filter
         continue;
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "watch-karma-tests": "karma start --no-single-run --reporters spec --auto-watch",
     "watch-karma-coverage": "CODE_COVERAGE=true npm run watch-karma-tests",
     "jpm-tests": "jpm test",
-    "travis-ci": "npm run jpm-tests -- -v && npm run karma-coverage && npm run lint",
+    "travis-ci": "npm run karma-coverage && npm run lint",
     "lint-content": "eslint data/inspector && eslint karma-tests/",
     "lint-addon": "eslint --env node lib",
     "lint": "npm run lint-content && npm run lint-addon"


### PR DESCRIPTION
This PR turns the Packets and Actors filtering into a case insensitive filtering.

I've tried to keep it as small as possible so we can include a fix to #37 in the upcoming 1.0.5 release.

In a follow up I'm going to introduce the new option to enable the optional "case sensitive" version, and I'm going to move the filtering in the packets and actors stores (which will help to simplify the React components which contains filter, and the stores is where the filtering should happen to keep this details out of the React components)