### PR TITLE
cache raw RDP packet string to optimize packets filtering

### DIFF
--- a/data/inspector/components/packet-list.js
+++ b/data/inspector/components/packet-list.js
@@ -79,7 +79,7 @@ var PacketList = React.createClass({
       }
 
       // Filter out packets which don't match the search token.
-      if (filter && JSON.stringify(packet).toLowerCase().indexOf(filter.toLowerCase()) < 0) {
+      if (filter && packet.rawPacket.toLowerCase().indexOf(filter.toLowerCase()) < 0) {
         continue;
       }
 

--- a/data/inspector/packets-store.js
+++ b/data/inspector/packets-store.js
@@ -84,6 +84,7 @@ PacketsStore.prototype =
   onSendPacket: function(event) {
     this.appendPacket({
       type: "send",
+      rawPacket: event.data,
       packet: JSON.parse(event.data),
       size: event.data.length,
       time: new Date()
@@ -93,6 +94,7 @@ PacketsStore.prototype =
   onReceivePacket: function(event) {
     this.appendPacket({
       type: "receive",
+      rawPacket: event.data,
       packet: JSON.parse(event.data),
       size: event.data.length,
       time: new Date()


### PR DESCRIPTION
Small follow up on #53, optimizing packets filtering by caching the raw RDP packet string.  