### PR TITLE
Filter out packets generated RDPi

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,9 @@
     "linebreak-style": [0],
     "eqeqeq": [0],
     "new-cap": [0],
-    "no-new": [0]
+    "no-new": [0],
+    "comma-dangle": [0],
+    "no-use-before-define": [0]
   },
   "env": {
     "es6": true,

--- a/data/inspector/components/packet-stack-sidepanel.js
+++ b/data/inspector/components/packet-stack-sidepanel.js
@@ -41,6 +41,7 @@ var PacketStackSidePanel = React.createClass({
           }
         }
         catch (e) {
+          /* eslint: no-empty-block: 0*/
         }
       }
     }

--- a/data/inspector/components/packet.js
+++ b/data/inspector/components/packet.js
@@ -12,7 +12,7 @@ const { Reps } = require("reps/reps");
 const { TreeView } = require("reps/tree-view");
 
 // RDP Inspector
-const { TextWithTooltip } = require("./text-with-tooltip");
+//const { TextWithTooltip } = require("./text-with-tooltip");
 
 // Constants
 const { DIV, SPAN, UL, LI, A } = Reps.DOM;
@@ -51,7 +51,7 @@ var Packet = React.createClass({
     var classNames = ["packetPanel", data.type];
     var size = Str.formatSize(data.size);
     var time = data.time;
-    var stack = data.stack;
+    //var stack = data.stack;
 
     // Use String.formatTime, but how to access from the content?
     var timeText = time.toLocaleTimeString() + "." + time.getMilliseconds();
@@ -69,9 +69,9 @@ var Packet = React.createClass({
       classNames.push("selected");
     }
 
-    var topFrame = stack.getTopFrame();
+    /*var topFrame = stack.getTopFrame();
     var stackFrameUrl = topFrame ? topFrame.getUrl() : null;
-    var stackFrame = topFrame ? topFrame.getLabel() : null;
+    var stackFrame = topFrame ? topFrame.getLabel() : null;*/
 
     // Inline preview component
     var preview = this.props.showInlineDetails ? TreeView(

--- a/data/inspector/components/packets-summary.js
+++ b/data/inspector/components/packets-summary.js
@@ -6,7 +6,6 @@ define(function(require, exports/*, module*/) {
 
 // ReactJS
 const React = require("react");
-const ReactBootstrap = require("react-bootstrap");
 
 // Firebug SDK
 const { Reps } = require("reps/reps");

--- a/data/inspector/components/stack-frame-rep.js
+++ b/data/inspector/components/stack-frame-rep.js
@@ -1,4 +1,5 @@
 /* See license.txt for terms of usage */
+/* globals postChromeMessage */
 
 define(function(require, exports /*, module */) {
 
@@ -15,7 +16,7 @@ const { ObjectBox } = require("reps/object-box");
 const { StackFrame } = require("../packets-store");
 
 // Constants
-const { DIV, SPAN, UL, LI, A } = Reps.DOM;
+const { SPAN } = Reps.DOM;
 
 /**
  * This component is responsible for rendering a stack frame.
@@ -35,7 +36,7 @@ var StackFrameRep = React.createClass({
         SPAN({className: "stackName"}, name + "()"),
         SPAN({className: "stackLabel", onClick: this.onViewSource}, label)
       )
-    )
+    );
   },
 
   onViewSource: function(event) {
@@ -58,7 +59,7 @@ var StackFrameRep = React.createClass({
 
 // Registration
 
-function supportsObject(object, type) {
+function supportsObject(object/*, type*/) {
   return object instanceof StackFrame;
 }
 

--- a/data/inspector/packets-store.js
+++ b/data/inspector/packets-store.js
@@ -156,23 +156,64 @@ PacketsStore.prototype =
   },
 
   doRefreshPackets: function() {
+    var packets = this.doFilterPacketsList(this.packets);
+
     var newState = {
-      packets: this.packets,
+      packets: packets,
       removedPackets: this.removedPackets
     };
 
     // Default selection
     if (!this.app.state.selectedPacket) {
-      var selection = this.packets.length ? this.packets[0] : null;
+      var selection = packets.length ? packets[0] : null;
       newState.selectedPacket = selection;
     }
 
     // If there are no packets clear the details side panel.
-    if (!this.packets.length) {
+    if (!packets.length) {
       newState.selectedPacket = null;
     }
 
     this.app.setState(newState);
+  },
+
+  doFilterPacketsList: function() {
+    var filterFrom = {};
+
+    return this.packets.filter((packet) => {
+      var actorId = packet.packet ? (packet.packet.to || packet.packet.from) : null;
+
+      // filter our all the RDPi actorInspector actor
+      if (actorId && actorId.indexOf("actorInspector") > 0) {
+        return false;
+      }
+
+      if (packet.type == "send") {
+        // filter sent RDP packets needed to register the RDPi actorInspector actor
+        if (packet.packet.rdpInspectorInternals == true) {
+          filterFrom[packet.packet.to] = filterFrom[packet.packet.to] || 0;
+          filterFrom[packet.packet.to] += 1;
+
+          return false;
+        }
+
+        // filter sent RDP packets needed to register the RDPi actorInspector actor
+        if (packet.packet.type == "registerActor" &&
+            packet.packet.filename.indexOf("rdpinspector-at-getfirebug-dot-com") > 0) {
+          filterFrom[packet.packet.to] = filterFrom[packet.packet.to] || 0;
+          filterFrom[packet.packet.to] += 1;
+          return false;
+        }
+      }
+
+      // filter received RDP packets needed to register the RDPi actorInspector actor
+      if (packet.type == "receive" && filterFrom[packet.packet.from] > 0) {
+        filterFrom[packet.packet.from] -= 1;
+        return false;
+      }
+
+      return true;
+    });
   },
 
   clear: function() {

--- a/data/inspector/packets-store.js
+++ b/data/inspector/packets-store.js
@@ -318,10 +318,10 @@ StackTrace.prototype = {
     return this.frames.length > 0;
   },
 
-  getTopFrame: function(stack) {
+  getTopFrame: function() {
     return this.hasFrames() ? this.frames[0] : null;
   },
-}
+};
 
 // StackFrame
 
@@ -352,13 +352,17 @@ StackFrame.prototype = {
   getUrl: function() {
     return this.url;
   }
-}
+};
 
 // Helpers
 
+/* NOTE: currently unused */
+/*
 function filterFrames(frames, pivot, onlyFirst) {
+  var frame;
+
   if (onlyFirst) {
-    for (var frame of frames) {
+    for (frame of frames) {
       if (frame.name == pivot) {
         frames.shift();
       } else {
@@ -370,7 +374,7 @@ function filterFrames(frames, pivot, onlyFirst) {
 
   var newFrames = [];
   var remove = true;
-  for (var frame of frames) {
+  for (frame of frames) {
     if (!remove) {
       newFrames.push(frame);
     }
@@ -387,6 +391,7 @@ function filterFrames(frames, pivot, onlyFirst) {
 
   return newFrames;
 }
+*/
 
 // Exports from this module
 exports.PacketsStore = PacketsStore;

--- a/karma-tests/components/main-tabbed-area-spec.js
+++ b/karma-tests/components/main-tabbed-area-spec.js
@@ -61,10 +61,15 @@ describe("MainTabbedArea React Component", function() {
   });
 
   it("renders a Packet on PacketsStore.sendPacket", function () {
+    var packet = JSON.stringify({
+      to: "root",
+      type: "requestTypes"
+    });
+
     packetsStore.onSendPacket({
       data: JSON.stringify({
-        to: "root",
-        type: "requestTypes"
+        packet: packet,
+        stack: []
       })
     });
 

--- a/lib/inspector-service.js
+++ b/lib/inspector-service.js
@@ -91,7 +91,10 @@ const InspectorService =
       prefix: "actorInspector",
       actorClass: "InspectorActor",
       frontClass: InspectorFront,
-      moduleUrl: actorModuleUrl
+      moduleUrl: actorModuleUrl,
+      // NOTE: the following option asks firebug.sdk to mark custom actors registering RDP packets
+      // as rdpInspectorInternals (which helps to filter out them from the packet list)
+      rdpInspectorInternals: true
     };
 
     let deferred = defer();

--- a/lib/toolbox-overlay.js
+++ b/lib/toolbox-overlay.js
@@ -10,7 +10,7 @@ module.metadata = {
 };
 
 // Add-on SDK
-const { Cu, components } = require("chrome");
+const { components } = require("chrome");
 const { Class } = require("sdk/core/heritage");
 const simplePrefs = require("sdk/simple-prefs");
 const { prefs } = simplePrefs;
@@ -176,7 +176,7 @@ const ToolboxOverlay = Class(
 
   getStack: function() {
     if (!Options.getPref("javascript.options.asyncstack")) {
-      return;
+      return [];
     }
 
     var frames = [];

--- a/lib/transport-observer.js
+++ b/lib/transport-observer.js
@@ -14,9 +14,9 @@ const { Class } = require("sdk/core/heritage");
 const { EventTarget } = require("sdk/event/target");
 
 // Firebug SDK
-const { Trace, TraceError } = require("firebug.sdk/lib/core/trace.js").get(module.id);
+const { Trace/*, TraceError*/ } = require("firebug.sdk/lib/core/trace.js").get(module.id);
 const { Arr } = require("firebug.sdk/lib/core/array.js");
-const { Options } = require("firebug.sdk/lib/core/options.js");
+//const { Options } = require("firebug.sdk/lib/core/options.js");
 
 /**
  * This object registers a listener in transport layer that is associated


### PR DESCRIPTION
This PR introduces a couple of small changes to fix #42

- marks packets generated by our custom inspector actor (by adding a custom ```rdpInspectorInternals``` attributes to the replies)
- filters requests marked by ```rdpInspectorInternals``` attribute and their expected related replies (by actor id)
- filters actorInspector requests and replies (matching the actor prefix in the ```to```/```from```)

NOTE: this PR depends on firebug/firebug.sdk#9 