### PR TITLE
reorganize eslint configs and add comments on rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,38 +1,23 @@
 {
-  "plugins": [
-    "no-tabs",
-    "react"
-  ],
   "rules": {
+    "indent": [2, 2], // check 2 space indentation
     "no-mixed-spaces-and-tabs": [2],
     "quotes": [2, "double"],
     "semi": [1, "always"],
 
-    "no-tabs/at-all": [2],
-
-    "react/display-name": 2,
-    "react/prop-types": 0,
-
-    "indent": [0, 2],
+    // disabled rule which enforce unix or windows line breaks
     "linebreak-style": [0],
-    "eqeqeq": [0],
-    "new-cap": [0],
-    "no-new": [0],
+
+    // disabled comma-dangle is safe for our use case
     "comma-dangle": [0],
-    "no-use-before-define": [0]
+
+    // disabled eqeqeq and no-use-before-define are safe if you use them correctly
+    "eqeqeq": [0],
+    "no-use-before-define": [0],
   },
   "env": {
-    "es6": true,
-    "browser": true,
-    "amd": true
+    "es6": true
   },
   "globals": {
-    "define": true,
-    "require": true,
-    "requirejs": true,
-
-    "Str": true,
-    "Locale": true,
-    "Options": true
   }
 }

--- a/data/.eslintrc
+++ b/data/.eslintrc
@@ -1,0 +1,35 @@
+// extends common eslintrc config with "javascript running in a content context" specific configs
+{
+    "extends": "../.eslintrc",
+		"plugins": [
+			// prevents tab whitespace when 'indent' rule is disabled
+	    "no-tabs",
+	    "react"
+	  ],
+		"env": {
+      // enable browser & amd conventions
+      "browser": true,
+			"amd": true
+    },
+    "rules": {
+			// disabled due to conflicts with special indentation in requirejs modules
+			"indent": 0,
+			// prevents any usage of tab whitespaces
+			"no-tabs/at-all": [2],
+
+			// force definition of displayName on React components
+			"react/display-name": 2,
+
+			// TODO: force propTypes on React Components
+	    "react/prop-types": 0,
+
+			// disabled due to conflicts with capitalized React components names
+			"new-cap": [0],
+    },
+    "globals": {
+      // firebug.sdk globals
+			"Str": true,
+			"Locale": true,
+			"Options": true
+    }
+}

--- a/data/inspector/config.js
+++ b/data/inspector/config.js
@@ -1,5 +1,7 @@
 /* See license.txt for terms of usage */
 
+/* globals requirejs */
+
 // RequireJS configuration
 require.config({
   baseUrl: ".",

--- a/data/inspector/main.js
+++ b/data/inspector/main.js
@@ -156,9 +156,12 @@ theApp = React.render(MainTabbedArea({
 
 // Helper modules for handling application events.
 packetsStore = new PacketsStore(window, theApp);
+
+/* eslint-disable no-new */
 new ActorsStore(window, theApp);
 new Resizer(window, theApp);
 new Search(window, theApp);
+/* eslint-enable */
 
 // Send notification about initialization being done.
 postChromeMessage("initialized");

--- a/karma-tests/.eslintrc
+++ b/karma-tests/.eslintrc
@@ -1,0 +1,7 @@
+// extends data eslintrc config with karma tests specific configs
+{
+    "extends": "../data/.eslintrc",
+    "env": {},
+    "rules": {},
+    "globals": {}
+}

--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,0 +1,18 @@
+// extends common eslintrc config with addon-sdk specific configs
+{
+    "extends": "../.eslintrc",
+    "env": {
+      // commonjs conventions
+      "node": true
+    },
+    "rules": {
+      "global-strict": 0,
+      "dot-notation": 0,
+      "new-cap": 0,
+      "no-underscore-dangle": 0
+    },
+    "globals": {
+      // firebug.sdk globals
+      "FBTrace": true
+    }
+}

--- a/lib/inspector-actor.js
+++ b/lib/inspector-actor.js
@@ -1,8 +1,4 @@
-
 /* See license.txt for terms of usage */
-
-/* globals exports */
-/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
 
 "use strict";
 

--- a/lib/inspector-front.js
+++ b/lib/inspector-front.js
@@ -1,8 +1,5 @@
 /* See license.txt for terms of usage */
 
-/* globals exports, module */
-/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
-
 "use strict";
 
 module.metadata = {

--- a/lib/inspector-service.js
+++ b/lib/inspector-service.js
@@ -105,14 +105,14 @@ const InspectorService =
       then(({registrar, front}) => {
         this.globalRegistrar = registrar;
         return front;
-    });
+      });
 
     // Register as tab actor.
     let tab = Rdp.registerTabActor(client, config).
       then(({registrar, front}) => {
         this.tabRegistrar = registrar;
         return front;
-    });
+      });
 
     // Wait till both registrations are done.
     all([global, tab]).then(results => {

--- a/lib/inspector-service.js
+++ b/lib/inspector-service.js
@@ -1,8 +1,5 @@
 /* See license.txt for terms of usage */
 
-/* globals exports, module */
-/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
-
 "use strict";
 
 module.metadata = {

--- a/lib/inspector-window.js
+++ b/lib/inspector-window.js
@@ -1,8 +1,5 @@
 /* See license.txt for terms of usage */
 
-/* globals exports, module, FBTrace */
-/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
-
 "use strict";
 
 module.metadata = {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,8 +1,5 @@
 /* See license.txt for terms of usage */
 
-/* globals exports, module */
-/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
-
 "use strict";
 
 // Firebug.SDK

--- a/lib/start-button.js
+++ b/lib/start-button.js
@@ -1,8 +1,5 @@
 /* See license.txt for terms of usage */
 
-/* globals exports, module */
-/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
-
 "use strict";
 
 module.metadata = {

--- a/lib/toolbox-overlay.js
+++ b/lib/toolbox-overlay.js
@@ -1,8 +1,5 @@
 /* See license.txt for terms of usage */
 
-/* globals exports, module */
-/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
-
 "use strict";
 
 module.metadata = {

--- a/lib/transport-observer.js
+++ b/lib/transport-observer.js
@@ -1,8 +1,5 @@
 /* See license.txt for terms of usage */
 
-/* globals exports, module */
-/* eslint global-strict: 0, dot-notation: 0, new-cap: 0, no-underscore-dangle: 0 */
-
 "use strict";
 
 module.metadata = {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jpm-tests": "jpm test",
     "travis-ci": "npm run karma-coverage && npm run lint",
     "lint-content": "eslint data/inspector && eslint karma-tests/",
-    "lint-addon": "eslint --env node lib",
+    "lint-addon": "eslint lib",
     "lint": "npm run lint-content && npm run lint-addon"
   },
   "engines": {


### PR DESCRIPTION
This PR introduces a small reorganization of the eslint configuration (using the ```extend``` feature of the eslintrc file) and adds comments to the rules (as documentation of the motivations)  