### PR TITLE
Fix karma config 

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,7 +23,7 @@ module.exports = function(config) {
     files: [
       'karma-tests/lib/firebug-sdk-shims.js',
       'karma-tests/test-main.js',
-      {pattern: 'node_modules/firebug.sdk/lib/reps/*.js', included: false },
+      {pattern: 'node_modules/firebug.sdk/lib/reps/**/*.js', included: false },
       {pattern: 'node_modules/firebug.sdk/skin/**/*', included: false},
       {pattern: 'data/**/*.js', included: false},
       {pattern: 'data/**/*.css', included: false},


### PR DESCRIPTION
This PR fixes the glob in the karma config, which includes firebug.sdk files during karma tests, to include the recently added 'lib/reps/core' files.