### PR TITLE
Fix missing close button on hover in the TreeEditorView component

### DIFF
--- a/data/inspector/css/tree-editor-view.css
+++ b/data/inspector/css/tree-editor-view.css
@@ -66,3 +66,8 @@
   background: yellow;
   color: black;
 }
+
+/* FIX: missing close button on hover */
+.closeButton:hover {
+  filter: url("resource://rdpinspector-at-getfirebug-dot-com/node_modules/firebug.sdk/skin/classic/shared/filters.svg#darken") !important;
+}


### PR DESCRIPTION
This PR includes a small workaround to fix the "missing close button on hover in the send packet tab" issue.