### PR TITLE
move special RDPi window globals into a module

### DIFF
--- a/data/.eslintrc
+++ b/data/.eslintrc
@@ -26,10 +26,5 @@
 			// disabled due to conflicts with capitalized React components names
 			"new-cap": [0],
     },
-    "globals": {
-      // firebug.sdk globals
-			"Str": true,
-			"Locale": true,
-			"Options": true
-    }
+    "globals": {}
 }

--- a/data/inspector/components/actors-panel.js
+++ b/data/inspector/components/actors-panel.js
@@ -14,6 +14,8 @@ const { Reps } = require("reps/repository");
 // RDP Inspector
 const { ActorsToolbar } = require("./actors-toolbar");
 
+const { Locale } = require("../rdp-inspector-window");
+
 // Shortcuts
 const { TR, TD, TABLE, TBODY, THEAD, TH, DIV, H4 } = Reps.DOM;
 

--- a/data/inspector/components/actors-toolbar.js
+++ b/data/inspector/components/actors-toolbar.js
@@ -15,6 +15,9 @@ var Button = React.createFactory(ReactBootstrap.Button);
 const { Reps } = require("reps/reps");
 const { SELECT, OPTION } = Reps.DOM;
 
+// RDP Window injected APIs
+const { Locale } = require("../rdp-inspector-window");
+
 /**
  * @template This object is responsible for rendering the toolbar
  * in Actors tab

--- a/data/inspector/components/main-tabbed-area.js
+++ b/data/inspector/components/main-tabbed-area.js
@@ -18,6 +18,9 @@ const TabbedArea = React.createFactory(ReactBootstrap.TabbedArea);
 const TabPane = React.createFactory(ReactBootstrap.TabPane);
 const Alert = React.createFactory(ReactBootstrap.Alert);
 
+// RDP Window injected APIs
+const { Locale } = require("../rdp-inspector-window");
+
 /**
  * @template This template is responsible for rendering the main
  * application UI. The UI consist from set of tabs (Packets and Actors)

--- a/data/inspector/components/packet.js
+++ b/data/inspector/components/packet.js
@@ -17,6 +17,9 @@ const { TreeView } = require("reps/tree-view");
 // Constants
 const { DIV, SPAN, UL, LI, A } = Reps.DOM;
 
+// RDP Window injected APIs
+const { Locale, Str } = require("../rdp-inspector-window");
+
 /**
  * @template This template is responsible for rendering a packet.
  * Packets are rendered within {@link PacketList} sorted by time.

--- a/data/inspector/components/packets-limit.js
+++ b/data/inspector/components/packets-limit.js
@@ -13,6 +13,9 @@ const { Reps } = require("reps/reps");
 // Constants
 const { DIV, SPAN } = Reps.DOM;
 
+// RDP Window injected APIs
+const { Locale } = require("../rdp-inspector-window");
+
 /**
  * @template This template is responsible for rendering a message
  * at the top of the packet list that informs the user about reaching

--- a/data/inspector/components/packets-summary.js
+++ b/data/inspector/components/packets-summary.js
@@ -13,6 +13,10 @@ const { Reps } = require("reps/reps");
 // RDP Inspector
 const { TextWithTooltip } = require("./text-with-tooltip");
 
+// RDP Window injected APIs
+const { Locale, Str } = require("../rdp-inspector-window");
+
+
 // Constants
 const { DIV } = Reps.DOM;
 

--- a/data/inspector/components/packets-toolbar.js
+++ b/data/inspector/components/packets-toolbar.js
@@ -1,5 +1,4 @@
 /* See license.txt for terms of usage */
-/* globals Locale */
 
 define(function(require, exports/*, module*/) {
 
@@ -19,6 +18,9 @@ var Tooltip = React.createFactory(ReactBootstrap.Tooltip);
 
 const { Reps } = require("reps/reps");
 const { SPAN, INPUT } = Reps.DOM;
+
+// RDP Window injected APIs
+const { Locale } = require("../rdp-inspector-window");
 
 /**
  * @template This object represents a template for a toolbar displayed

--- a/data/inspector/components/stack-frame-rep.js
+++ b/data/inspector/components/stack-frame-rep.js
@@ -1,5 +1,4 @@
 /* See license.txt for terms of usage */
-/* globals postChromeMessage */
 
 define(function(require, exports /*, module */) {
 
@@ -17,6 +16,9 @@ const { StackFrame } = require("../packets-store");
 
 // Constants
 const { SPAN } = Reps.DOM;
+
+// RDP Window injected APIs
+const { postChromeMessage } = require("../rdp-inspector-window");
 
 /**
  * This component is responsible for rendering a stack frame.

--- a/data/inspector/main.js
+++ b/data/inspector/main.js
@@ -1,5 +1,4 @@
 /* See license.txt for terms of usage */
-/* globals postChromeMessage */
 
 define(function(require/*, exports, module*/) {
 
@@ -17,6 +16,9 @@ var { Search } = require("search");
 
 // Reps
 require("./components/stack-frame-rep");
+
+// RDP Window injected APIs
+var { Locale, postChromeMessage } = require("./rdp-inspector-window");
 
 var packetsStore;
 var theApp;

--- a/data/inspector/packets-store.js
+++ b/data/inspector/packets-store.js
@@ -1,9 +1,11 @@
 /* See license.txt for terms of usage */
-/* globals Options */
 
 define(function(require, exports/*, module*/) {
 
 "use strict";
+
+// RDP Window injected APIs
+const { Options } = require("./rdp-inspector-window");
 
 // Constants
 const refreshTimeout = 200;

--- a/data/inspector/rdp-inspector-window.js
+++ b/data/inspector/rdp-inspector-window.js
@@ -1,0 +1,48 @@
+/* See license.txt for terms of usage */
+
+define(function(require, exports/*, module*/) {
+
+"use strict";
+
+if (["http:", "https:", "file:"].indexOf(window.location.protocol) >= 0) {
+    // NOTE: add RDPi injected APIs shims, to be able to run the React UI in a tab
+    exports.Locale = window.Locale = {
+      $STR: function(s) { return s; }
+    };
+
+    exports.Options = window.Options = {
+      getPref: function(key) {
+        /* eslint no-console: 0 */
+        switch(key) {
+        case "extensions.rdpinspector.packetLimit":
+          return 100;
+        default:
+          throw Error("UNKNOWN Option.getPref: " + key);
+        }
+      }
+    };
+
+    exports.Str = window.Str = {
+      formatSize: function(str) { return str; }
+    };
+
+    exports.Trace = window.Trace = {
+      sysout: function(...args) {
+        console.log.apply(console, args);
+      }
+    };
+
+    exports.postChromeMessage = window.postChromeMessage = function() {
+      console.log("POST CHROME MESSAGE", arguments);
+    };
+} else {
+  /* globals Str, Locale, Options, Trace, postChromeMessage */
+  exports.Str = Str;
+  exports.Locale = Locale;
+  exports.Options = Options;
+  exports.Trace = Trace;
+
+  exports.postChromeMessage = postChromeMessage;
+}
+
+});


### PR DESCRIPTION
this PR introduces a new small "data/inspector/rdp-inspector-window.js" module, this module is the only one in the project which uses the custom injected globals directly (the custom globals injected by this addon in the content frame where the React UI is running).

This "rdp-inspector-window" module auto-detects when the page is running over http/https or file urls and mocks the missing globals.

This change has two goals:

- restrict the use of these globals to a single module (and remove these globals from the data/.eslintrc file)
- main.html can be loaded unmodified in a tab (over http/https or file urls) and we can inspect the React UI with the React DevTools