### PR TITLE
Fix module paths (bug 912121)

### DIFF
--- a/lib/inspector-actor.js
+++ b/lib/inspector-actor.js
@@ -6,8 +6,15 @@
 const { Cu } = require("chrome");
 
 // DevTools
-const { DebuggerServer } = Cu.import("resource://gre/modules/devtools/dbg-server.jsm", {});
-const { devtools } = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
+// See also: https://bugzilla.mozilla.org/show_bug.cgi?id=912121
+var devtools;
+try {
+  devtools = Cu.import("resource://gre/modules/devtools/shared/Loader.jsm", {}).devtools;
+} catch (err) {
+  devtools = Cu.import("resource://gre/modules/devtools/Loader.jsm", {}).devtools;
+}
+
+const { DebuggerServer } = devtools["require"]("devtools/server/main");
 const protocol = devtools["require"]("devtools/server/protocol");
 const { method, RetVal, ActorClass, Actor } = protocol;
 

--- a/lib/inspector-front.js
+++ b/lib/inspector-front.js
@@ -6,14 +6,12 @@ module.metadata = {
   "stability": "experimental"
 };
 
-// Add-on SDK
-const { Cu } = require("chrome");
-
 // Firebug SDK
 const { Trace/*, TraceError*/ } = require("firebug.sdk/lib/core/trace.js").get(module.id);
 
 // DevTools
-const { devtools } = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
+// See also: https://bugzilla.mozilla.org/show_bug.cgi?id=912121
+const { devtools } = require("firebug.sdk/lib/core/devtools.js");
 const { Front, FrontClass } = devtools["require"]("devtools/server/protocol");
 
 // RDP Inspector

--- a/lib/inspector-service.js
+++ b/lib/inspector-service.js
@@ -17,8 +17,14 @@ const { Trace/*, TraceError*/ } = require("firebug.sdk/lib/core/trace.js").get(m
 const { Rdp } = require("firebug.sdk/lib/core/rdp.js");
 
 // DevTools
-const { DebuggerClient } = Cu.import("resource://gre/modules/devtools/dbg-client.jsm", {});
-const { devtools } = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
+// See also: https://bugzilla.mozilla.org/show_bug.cgi?id=912121
+const { devtools } = require("firebug.sdk/lib/core/devtools.js");
+var DebuggerClient;
+try {
+  DebuggerClient = devtools["require"]("devtools/shared/client/main").DebuggerClient;
+} catch(e) {
+  DebuggerClient = Cu.import("resource://gre/modules/devtools/dbg-client.jsm", {}).DebuggerClient;
+}
 const { on, off } = devtools["require"]("sdk/event/core");
 
 // RDP Inspector

--- a/lib/start-button.js
+++ b/lib/start-button.js
@@ -30,8 +30,8 @@ const { AREA_PANEL, AREA_NAVBAR } = CustomizableUI;
 const { AddonManager } = Cu.import("resource://gre/modules/AddonManager.jsm", {});
 
 // DevTools
-const { gDevTools } = Cu.import("resource:///modules/devtools/gDevTools.jsm", {});
-const { devtools } = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
+// See also: https://bugzilla.mozilla.org/show_bug.cgi?id=912121
+const { devtools, gDevTools } = require("firebug.sdk/lib/core/devtools.js");
 
 // RDP Inspector
 const { ToolboxOverlay } = require("./toolbox-overlay");

--- a/lib/webide-connections-monitor.js
+++ b/lib/webide-connections-monitor.js
@@ -13,12 +13,16 @@ const { ToolboxOverlay } = require("./toolbox-overlay");
 // Firebug SDK
 const { Dispatcher } = require("firebug.sdk/lib/dispatcher");
 const { Trace/*, TraceError*/ } = require("firebug.sdk/lib/core/trace.js").get(module.id);
-const { System } = require("firebug.sdk/lib/core/system");
 
 // DevTools
-const { ConnectionManager, Connection } = System.devtoolsRequire("devtools/client/connection-manager");
-const { AppManager } = System.devtoolsRequire("devtools/webide/app-manager");
-
+// See also: https://bugzilla.mozilla.org/show_bug.cgi?id=912121
+const { devtools, safeRequire } = require("firebug.sdk/lib/core/devtools");
+const {
+  ConnectionManager, Connection
+} = safeRequire(devtools, "devtools/client/connection-manager", "devtools/shared/client/connection-manager");
+const {
+  AppManager
+} = safeRequire(devtools, "devtools/webide/app-manager", "devtools/client/webide/modules/app-manager");
 
 const WebIDEConnectionsMonitor =
 /** @lends ConnectionsMonitor */

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     }
   ],
   "dependencies": {
-    "firebug.sdk": "~0.6.3"
+    "firebug.sdk": "~0.6.7"
   },
   "devDependencies": {
     "eslint": "^0.21.0",

--- a/test/test-inspector-service.js
+++ b/test/test-inspector-service.js
@@ -2,12 +2,10 @@
 
 const { InspectorService } = require("../lib/inspector-service");
 
-const { Cu } = require("chrome");
 const { getMostRecentBrowserWindow } = require("sdk/window/utils");
 
 // DevTools
-const { gDevTools } = Cu.import("resource:///modules/devtools/gDevTools.jsm", {});
-const { devtools } = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
+const { devtools, gDevTools } = require("firebug.sdk/lib/core/devtools.js");
 
 function showToolbox(toolId) {
   let browser = getMostRecentBrowserWindow();


### PR DESCRIPTION
This PR updates firebug.sdk dependency (which introduces the related fixes merged directly in firebug.sdk) and fixes the remaining paths.

once merged it should fix #68