### PR TITLE
detach registered inspector actors on RDPi window close

### DIFF
--- a/lib/inspector-window.js
+++ b/lib/inspector-window.js
@@ -238,6 +238,15 @@ const InspectorWindow = Class(
   onClose: function(event) {
     Trace.sysout("InspectorWindow.onClose; " + event, arguments);
 
+    if (this.inspectorActorClients) {
+      let { global, tab } = this.inspectorActorClients;
+      if (global) {
+        global.detach();
+      }
+      if (tab) {
+        tab.detach();
+      }
+    }
     this.toolboxOverlay.removeTransportListener(this);
 
     this.win = null;


### PR DESCRIPTION
This PR ensures that the inspector actors' detach method is called when the RDPi window is closed, which prevents the "Wrong State" exception described in #70 to be raised if we "close and re-open" the RDPi window on a defined debugging connection.