### PR TITLE
prepare to support new devtools resource urls with fallbacks

### DIFF
--- a/lib/inspector-actor.js
+++ b/lib/inspector-actor.js
@@ -5,14 +5,36 @@
 // Add-on SDK
 const { Cu } = require("chrome");
 
-// DevTools
-// See also: https://bugzilla.mozilla.org/show_bug.cgi?id=912121
-var devtools;
-try {
-  devtools = Cu.import("resource://gre/modules/devtools/shared/Loader.jsm", {}).devtools;
-} catch (err) {
-  devtools = Cu.import("resource://gre/modules/devtools/Loader.jsm", {}).devtools;
+/**
+ * Allows importing a JS module (Firefox platform) and specify alternative locations
+ * to keep backward compatibility in case when the module location changes.
+ * It helps Firebug to support multiple Firefox versions.
+ *
+ * @param {Array} locations List of URLs to try when importing the module.
+ * @returns Scope of the imported module or an empty scope if module wasn't successfully loaded.
+ */
+function safeImport(...args) {
+  for (var i = 0; i < args.length; i++) {
+    try {
+      return Cu["import"](args[i], {});
+    }
+    /* eslint-disable */
+    catch (err) {
+    }
+    /* eslint-enable */
+  }
+  return {};
 }
+
+// DevTools
+// See also:
+// - https://bugzilla.mozilla.org/show_bug.cgi?id=912121
+// - https://bugzilla.mozilla.org/show_bug.cgi?id=1203159
+const devtools = safeImport(
+  "resource://devtools/shared/Loader.jsm",
+  "resource://gre/modules/devtools/shared/Loader.jsm",
+  "resource://gre/modules/devtools/Loader.jsm"
+).devtools;
 
 const { DebuggerServer } = devtools["require"]("devtools/server/main");
 const protocol = devtools["require"]("devtools/server/protocol");


### PR DESCRIPTION
This PR (with is connected to the firebug/firebug#16) adds the safeImport helper in the context of the injected actor to add the new devtools resource urls (introduced by https://bugzilla.mozilla.org/show_bug.cgi?id=1203159) to the supported fallback urls.