### PR TITLE
Enable rdp-inspector on any client RDP connection

### DIFF
--- a/lib/inspector-service.js
+++ b/lib/inspector-service.js
@@ -22,7 +22,8 @@ const { Rdp } = require("firebug.sdk/lib/core/rdp.js");
 
 // DevTools
 // See also: https://bugzilla.mozilla.org/show_bug.cgi?id=912121
-const { devtools } = require("firebug.sdk/lib/core/devtools.js");
+const { devtools, gDevTools } = require("firebug.sdk/lib/core/devtools.js");
+
 var DebuggerClient;
 try {
   DebuggerClient = devtools["require"]("devtools/shared/client/main").DebuggerClient;
@@ -82,23 +83,24 @@ const InspectorService =
   getConnectionsInfo() {
     let localTabsConnections = [];
     let webideConnections = [];
+    let otherConnections = [];
 
     for (let conn of this.clientsMap.values()) {
-      // filter out incomplete connections
-      if (!conn.toolbox) {
-        continue;
-      }
-
       let connDesc = { uuid: conn.uuid };
 
       if (conn.webide) {
         connDesc.name = conn.webide.selectedRuntime.name;
 
         webideConnections.push(connDesc);
-      } else if (conn.toolbox.target.isLocalTab) {
+      } else if (conn.toolbox && conn.toolbox.target.isLocalTab) {
         connDesc.name = conn.toolbox.target.tab.label;
 
         localTabsConnections.push(connDesc);
+      } else {
+        otherConnections.push({
+          uuid: conn.uuid,
+          name: conn.uuid,
+        });
       }
     }
 
@@ -110,6 +112,10 @@ const InspectorService =
       "webide": {
         label: Locale.$STR("rdpConnections.tab.WebIDE"),
         connections: webideConnections
+      },
+      "other": {
+        label: "Other",
+        connections: otherConnections
       }
     };
 
@@ -118,9 +124,20 @@ const InspectorService =
 
   openRDPInspectorWindow(uuidConn) {
     if (this.clientsByUUID.has(uuidConn)) {
-      let { toolbox } = this.clientsByUUID.get(uuidConn);
+      let conn = this.clientsByUUID.get(uuidConn);
+      let { toolbox } = conn;
 
-      Dispatcher.emit("onToggleRDPInspector", [{ toolbox }]);
+      if (toolbox) {
+        Dispatcher.emit("onToggleRDPInspector", [{ toolbox }]);
+      } else {
+        toolbox = new devtools.Toolbox({
+          makeRemote: function() {},
+          client: conn.client,
+          on: () => {}
+        }, null, devtools.Toolbox.HostType.WINDOW);
+        toolbox.isFakeToolbox = true;
+        gDevTools.emit("toolbox-created", toolbox);
+      }
     }
   },
 
@@ -129,7 +146,8 @@ const InspectorService =
       return;
     }
     let clientInfo = this.clientsMap.get(client) || {
-      uuid: uuid().toString()
+      uuid: uuid().toString(),
+      client
     };
 
     delete moreInfo["uuid"];
@@ -149,7 +167,7 @@ const InspectorService =
 
     let autoOpenInspectorConsole = false;
 
-    if (clientInfo && clientInfo.webide && prefs.autoOpenOnWebIDEConnection) {
+    if (toolbox.isFakeToolbox || (clientInfo && clientInfo.webide && prefs.autoOpenOnWebIDEConnection)) {
       autoOpenInspectorConsole = true;
     }
 
@@ -170,7 +188,7 @@ const InspectorService =
 
   // WebIDE Connections Events
 
-  onWebIDEConnectionCreated: function(/*{ connection }*/) {
+  onWebIDEConnectionCreated: function(/*{ connection, selectedRuntime }*/) {
     Trace.sysout("InspectorService.onWebIDEConnectionCreated");
   },
 
@@ -180,6 +198,8 @@ const InspectorService =
     this._setClientInfo(connection.client, {
       webide: { selectedRuntime, connection }
     });
+
+    Dispatcher.emit("onRDPConnectionsUpdated", []);
   },
 
   // Start button events
@@ -191,7 +211,9 @@ const InspectorService =
 
     let clientInfo = this.clientsMap.get(toolbox.target.client);
 
-    if (clientInfo && clientInfo.webide) {
+    if (toolbox.isFakeToolbox) {
+      inspectorWindowName = `Other: ${clientInfo.uuid}`;
+    } else if (clientInfo && clientInfo.webide) {
       inspectorWindowName = `WebIDE: ${clientInfo.webide.selectedRuntime.name}`;
     } else if (toolbox.target.isLocalTab) {
       inspectorWindowName = `Tab: ${toolbox.target.tab.label}`;
@@ -210,6 +232,9 @@ const InspectorService =
     client.addOneTimeListener("closed", () => {
       this.onDebuggerClientClosed(client);
     });
+
+    this._setClientInfo(client, {});
+    Dispatcher.emit("onRDPConnectionsUpdated", []);
   },
 
   onDebuggerClientClosed: function(client) {

--- a/lib/webide-connections-monitor.js
+++ b/lib/webide-connections-monitor.js
@@ -48,9 +48,9 @@ const WebIDEConnectionsMonitor =
   onNewConnection: function(type, connection) {
     Trace.sysout("WebIDEConnectionsMonitor.onNewConnection;", arguments);
 
-    Dispatcher.emit("onWebIDEConnectionCreated", [{ connection }]);
+    Dispatcher.emit("onWebIDEConnectionCreated", [{ connection, selectedRuntime: AppManager.selectedRuntime }]);
 
-    connection.on(Connection.Events.CONNECTED, () => {
+    connection.once(Connection.Events.CONNECTED, () => {
       if (AppManager.connection == connection) {
 
         Dispatcher.emit("onWebIDEConnectionReady", [{ connection, selectedRuntime: AppManager.selectedRuntime }]);


### PR DESCRIPTION
This PR applies small changes to be able to connect the RDPInspector on any client RDP connection:

- add a new "Other" tab in the connection list window
- create a fake toolbox if the connection doesn't have its own
- list a webide connection before a real toolbox is available