### PR TITLE
Subscribe to the renamed transport events

### DIFF
--- a/lib/transport-observer.js
+++ b/lib/transport-observer.js
@@ -48,6 +48,11 @@ const TransportObserver = Class(
     transport.on("onBulkPacket", this.onBulkPacket);
     transport.on("startBulkSend", this.startBulkSend);
     transport.on("onClosed", this.onClosed);
+
+    transport.on("packet", this.onPacket);
+    transport.on("bulkpacket", this.onBulkPacket);
+    transport.on("startbulksend", this.startBulkSend);
+    transport.on("close", this.onClosed);
   },
 
   destroy: function() {
@@ -59,6 +64,11 @@ const TransportObserver = Class(
     transport.off("onBulkPacket", this.onBulkPacket);
     transport.off("startBulkSend", this.startBulkSend);
     transport.off("onClosed", this.onClosed);
+
+    transport.off("packet", this.onPacket);
+    transport.off("bulkpacket", this.onBulkPacket);
+    transport.off("startbulksend", this.startBulkSend);
+    transport.off("close", this.onClosed);
   },
 
   // Connection Events


### PR DESCRIPTION
Fixes issue #82: subscribe to the transport events with new names ([bug 1290599](https://bugzilla.mozilla.org/show_bug.cgi?id=1290599)).

Subscribes to both old and new names, so RDP inspector remains compatible with older versions.

@janodvarko: Any tests I need to add or update? The patched version works very well for me with the latest Nightly.
